### PR TITLE
Revert "Update Helm release netdata to v3.7.135"

### DIFF
--- a/charts/services/templates/netdata.yaml
+++ b/charts/services/templates/netdata.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   chart: netdata
   repo: https://netdata.github.io/helmchart/
-  version: 3.7.135
+  version: 3.7.130
   targetNamespace: default
   valuesContent: |-
     ingress:


### PR DESCRIPTION
Reverts arch-anes/self-hosted-services#255

```
touch: cannot touch '/etc/netdata/.opt-out-from-anonymous-statistics'
```