### PR TITLE
Fix firewall rules not getting applied for existing connections

### DIFF
--- a/roles/common/handlers/main.yml
+++ b/roles/common/handlers/main.yml
@@ -26,10 +26,10 @@
     name: network
     state: reloaded
 
-- name: Reload firewall
+- name: Restart firewall
   ansible.builtin.service:
     name: firewall
-    state: reloaded
+    state: restarted
 
 - name: Restart nginx
   ansible.builtin.service:

--- a/roles/haproxy/tasks/firewall.yml
+++ b/roles/haproxy/tasks/firewall.yml
@@ -14,4 +14,4 @@
       proto: all
       target: ACCEPT
     autocommit: true
-  notify: Reload firewall
+  notify: Restart firewall

--- a/roles/haproxy/tasks/port_forwarding.yml
+++ b/roles/haproxy/tasks/port_forwarding.yml
@@ -25,4 +25,4 @@
     - { name: IMAP, port: '993', proto: tcp }
   loop_control:
     label: "{{ item.name }}"
-  notify: Reload firewall
+  notify: Restart firewall

--- a/roles/qos/tasks/disable.yml
+++ b/roles/qos/tasks/disable.yml
@@ -8,7 +8,7 @@
   ignore_errors: true
 
 - name: Enable hardware flow offloading
-  notify: Reload firewall
+  notify: Restart firewall
   community.openwrt.uci:
     command: set
     key: "firewall.@defaults[0].{{ item }}"

--- a/roles/qos/tasks/enable.yml
+++ b/roles/qos/tasks/enable.yml
@@ -1,6 +1,6 @@
 ---
 - name: Disable Flow Offloading (Required for SQM)
-  notify: Reload firewall
+  notify: Restart firewall
   community.openwrt.uci:
     command: set
     key: "firewall.@defaults[0].{{ item }}"


### PR DESCRIPTION
When flow offloading is active, established connections are pushed down to the kernel's flowtable (or hardware NAT engine on GL.iNet devices). These offloaded flows bypass netfilter entirely. When you reload the firewall and add new zones/forwardings, already-offloaded connections don't see the new rules. New connections do, but since the Tailscale tunnel was already established, its traffic stayed in the stale offload path. Toggling offloading forces all flows back through the normal netfilter path, picking up the new rules. The fix is to restart the firewall (which flushes the flowtable) instead of just reloading it