### PR TITLE
Increases max file size and fixes random nextcloud-nginc failures

### DIFF
--- a/charts/services/templates/nextcloud.yaml
+++ b/charts/services/templates/nextcloud.yaml
@@ -63,7 +63,7 @@ spec:
           real_ip_recursive on;
 
           # set max upload size and increase upload timeout:
-          client_max_body_size 10G;
+          client_max_body_size 100G;
           client_body_timeout 300s;
           fastcgi_buffers 64 4K;
 
@@ -88,6 +88,15 @@ spec:
       trustedDomains:
         - nextcloud.{{ .Values.fqdn }}
       phpConfigs:
+        www.conf: |
+          [www]
+          user = www-data
+          group = www-data
+          pm = dynamic
+          pm.max_children = 350
+          pm.start_servers = 80
+          pm.min_spare_servers = 80
+          pm.max_spare_servers = 268
         custom-php-config.ini: |
           apc.shm_size=1G
           apc.ttl=7200


### PR DESCRIPTION
# Description 
When uploading many large files at the same time it would always fail after a few minutes. Some of the files would upload but I had to redo the operation multiple times until it would fully succeed. That said, files that were >10GB would never succeed. This branch fixes this issue.

# Tests 
<img width="1151" height="110" alt="image" src="https://github.com/user-attachments/assets/7d550e7d-1365-41f1-8d76-dbd6877d8f29" />
no restarts after 48h

I was able to upload files that are over 10GB without issues and without causing any failures