### PR TITLE
Add Frigate

### DIFF
--- a/charts/services/templates/frigate.yaml
+++ b/charts/services/templates/frigate.yaml
@@ -25,7 +25,7 @@ spec:
   targetNamespace: "{{ .Values.applicationsNamespace }}"
   valuesContent: |-
     image: 
-      tag: 0.17.0-rc1
+      tag: 0.17.0-rc2
     {{- $frigateConfig := .Values.applications.frigate }}
     frigateConfig:
       tls:

--- a/charts/services/templates/frigate.yaml
+++ b/charts/services/templates/frigate.yaml
@@ -1,0 +1,280 @@
+{{- if and (not .Values.disableAllApplications) .Values.applications.frigate.enabled }}
+# ---
+# apiVersion: v1
+# kind: Secret
+# metadata:
+#   name: frigate-credentials
+#   namespace: "{{ .Values.applicationsNamespace }}"
+# type: Opaque
+# stringData:
+#   # Camera RTSP credentials (for Dahua/EmpireTech cameras)
+#   rtsp-user: "admin"
+#   rtsp-password: "your_camera_password"
+#   # MQTT credentials (if using authenticated MQTT)
+#   mqtt-password: "your_mqtt_password"
+
+---
+apiVersion: helm.cattle.io/v1
+kind: HelmChart
+metadata:
+  name: frigate
+  namespace: "{{ .Values.applicationsNamespace }}"
+spec:
+  chart: oci://oci.trueforge.org/truecharts/frigate
+  version: 18.15.20
+  targetNamespace: "{{ .Values.applicationsNamespace }}"
+  valuesContent: |-
+    image: 
+      tag: 0.17.0-rc1
+    {{- $frigateConfig := .Values.applications.frigate }}
+    frigateConfig:
+      tls:
+        enabled: false
+      mqtt:
+        enabled: false
+      # go2rtc configuration for better live view streaming
+      go2rtc:
+        streams:
+          {{- range $name, $cam := $frigateConfig.cameras }}
+          {{- if $cam.enabled | default true }}
+          {{ $name }}:
+            {{- if $cam.rtsp_url }}
+            - {{ $cam.rtsp_url | quote }}
+            {{- else }}
+            # Main stream for high quality live view
+            - "rtsp://{FRIGATE_RTSP_USER}:{FRIGATE_RTSP_PASSWORD}@{{ $cam.ip }}/cam/realmonitor?channel={{ $cam.channel | default 1 }}&subtype=0"
+            {{- end }}
+          {{ $name }}_sub:
+            {{- if $cam.rtsp_url_sub }}
+            - {{ $cam.rtsp_url_sub | quote }}
+            {{- else }}
+            # Sub stream for detection
+            - "rtsp://{FRIGATE_RTSP_USER}:{FRIGATE_RTSP_PASSWORD}@{{ $cam.ip }}/cam/realmonitor?channel={{ $cam.channel | default 1 }}&subtype=1"
+            {{- end }}
+          {{- end }}
+          {{- end }}
+      
+      {{- if $frigateConfig.detectors }}
+      detectors:
+        {{- toYaml $frigateConfig.detectors | nindent 8 }}
+      {{- else }}
+      detectors:
+        cpu1:
+          type: cpu
+      {{- end }}
+      model:
+        width: 300
+        height: 300
+        input_tensor: nhwc
+        input_pixel_format: bgr
+        path: /openvino-model/ssdlite_mobilenet_v2.xml
+        labelmap_path: /openvino-model/coco_91cl_bkgr.txt
+      {{- if eq $frigateConfig.gpu_vendor "intel" }}
+      ffmpeg:
+        hwaccel_args: preset-vaapi
+      {{- else if eq $frigateConfig.gpu_vendor "intel_xe" }}
+      ffmpeg:
+        hwaccel_args: preset-vaapi
+      {{- else if eq $frigateConfig.gpu_vendor "nvidia" }}
+      ffmpeg:
+        hwaccel_args: preset-nvidia-h264
+      {{- end }}
+      {{- if $frigateConfig.motion }}
+      motion:
+        {{- toYaml $frigateConfig.motion | nindent 8 }}
+      {{- end }}
+      {{- if $frigateConfig.objects }}
+      objects:
+        {{- toYaml $frigateConfig.objects | nindent 8 }}
+      {{- end }}
+      face_recognition:
+        enabled: true
+      record:
+        enabled: {{ $frigateConfig.record.enabled | default true }}
+        continuous: # TODO REMOVE, should only be in inventory
+          days: {{ $frigateConfig.record.retain_days | default 7 }}
+        alerts:
+          retain:
+            days: {{ $frigateConfig.record.alerts_retain_days | default 30 }}
+        detections:
+          retain:
+            days: {{ $frigateConfig.record.detections_retain_days | default 30 }}
+      
+      snapshots:
+        enabled: {{ $frigateConfig.snapshots.enabled | default true }}
+        retain:
+          default: {{ $frigateConfig.snapshots.retain_days | default 30 }}
+      
+      cameras:
+        {{- range $name, $cam := $frigateConfig.cameras }}
+        {{ $name }}:
+          enabled: {{ $cam.enabled | default true }}
+          {{- if $cam.detect }}
+          detect:
+            enabled: true
+            {{- if $cam.detect.width }}
+            width: {{ $cam.detect.width }}
+            {{- end }}
+            {{- if $cam.detect.height }}
+            height: {{ $cam.detect.height }}
+            {{- end }}
+            fps: {{ $cam.detect.fps | default 10 }}
+          {{- else }}
+          detect:
+            enabled: true
+            fps: 10
+          {{- end }}
+          ffmpeg:
+            inputs:
+              {{- if $cam.rtsp_url }}
+              - path: {{ $cam.rtsp_url | quote }}
+                roles:
+                  - detect
+                  - record
+              {{- else }}
+              # Dahua/EmpireTech camera RTSP format
+              # Main stream (high quality for recording) - via go2rtc restream
+              - path: "rtsp://127.0.0.1:8554/{{ $name }}"
+                input_args: preset-rtsp-restream
+                roles:
+                  - record
+              # Sub stream (lower quality for detection - uses less CPU) - via go2rtc restream
+              - path: "rtsp://127.0.0.1:8554/{{ $name }}_sub"
+                input_args: preset-rtsp-restream
+                roles:
+                  - detect
+              {{- end }}
+          {{- if $cam.live }}
+          live:
+            {{- toYaml $cam.live | nindent 12 }}
+          {{- end }}
+          {{- if $cam.motion }}
+          motion:
+            {{- toYaml $cam.motion | nindent 12 }}
+          {{- end }}
+          {{- if $cam.zones }}
+          zones:
+            {{- toYaml $cam.zones | nindent 12 }}
+          {{- end }}
+          {{- if $cam.objects }}
+          objects:
+            {{- toYaml $cam.objects | nindent 12 }}
+          {{- end }}
+          {{- if $cam.onvif }}
+          onvif:
+            host: {{ $cam.ip }}
+            port: {{ $cam.onvif.port | default 80 }}
+            user: "{FRIGATE_RTSP_USER}"
+            password: "{FRIGATE_RTSP_PASSWORD}"
+          {{- end }}
+        {{- end }}
+    
+    workload:
+      main:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        podSpec:
+          annotations:
+            backup.velero.io/backup-volumes: config
+          containers:
+            main:
+              probes:
+                liveness:
+                  type: http
+                  path: /api/
+                  port: 5000
+                readiness:
+                  type: http
+                  path: /api/
+                  port: 5000
+                startup:
+                  type: http
+                  path: /api/
+                  port: 5000
+              env:
+                {{- if $frigateConfig.mqtt }}
+                {{- if $frigateConfig.mqtt.user }}
+                FRIGATE_MQTT_USER: {{ $frigateConfig.mqtt.user | quote }}
+                FRIGATE_MQTT_PASSWORD:
+                  secretKeyRef:
+                    name: frigate-credentials
+                    key: mqtt-password
+                    expandObjectName: false
+                {{- end }}
+                {{- end }}
+                FRIGATE_RTSP_USER:
+                  secretKeyRef:
+                    name: frigate-credentials
+                    key: rtsp-user
+                    expandObjectName: false
+                FRIGATE_RTSP_PASSWORD:
+                  secretKeyRef:
+                    name: frigate-credentials
+                    key: rtsp-password
+                    expandObjectName: false
+              resources:
+                requests:
+                  memory: 1Gi
+                  cpu: 500m
+                limits:
+                  memory: 4Gi
+                  {{- $gpuVendor := $frigateConfig.gpu_vendor }}
+                  {{- if eq $gpuVendor "intel" }}
+                    {{- if not $.Values.applications.intel_gpu.enabled }}
+                      {{- fail "Intel GPU is selected for Frigate but intel_gpu is not enabled" }}
+                    {{- end }}
+                  gpu.intel.com/i915: 1
+                  {{- else if eq $gpuVendor "intel_xe" }}
+                    {{- if not $.Values.applications.intel_gpu.enabled }}
+                      {{- fail "Intel GPU is selected for Frigate but intel_gpu is not enabled" }}
+                    {{- end }}
+                  gpu.intel.com/xe: 1
+                  {{- else if eq $gpuVendor "nvidia" }}
+                    {{- if not $.Values.applications.nvidia_gpu.enabled }}
+                      {{- fail "NVIDIA GPU is selected for Frigate but nvidia_gpu is not enabled" }}
+                    {{- end }}
+                  nvidia.com/gpu: 1
+                  {{- else if eq $gpuVendor "amd" }}
+                    {{- if not $.Values.applications.amd_gpu.enabled }}
+                      {{- fail "AMD GPU is selected for Frigate but amd_gpu is not enabled" }}
+                    {{- end }}
+                  amd.com/gpu: 1
+                  {{- else if $gpuVendor }}
+                    {{- fail (printf "Unknown GPU vendor '%s' selected for Frigate" $gpuVendor) }}
+                  {{- end }}
+    persistence:
+      config:
+        enabled: true
+        storageClass: local-path-persistent-namespaced
+        size: 1Gi
+      media:
+        enabled: true
+        {{- if $frigateConfig.nfs_media }}
+        existingClaim: nfs-{{ $frigateConfig.nfs_media }}
+        {{- else }}
+        storageClass: local-path-persistent-namespaced
+        size: {{ $frigateConfig.media_storage_size | default "100Gi" }}
+        {{- end }}
+    global:
+      traefik:
+        fixedMiddlewares: []
+    service:
+      main:
+        ports:
+          main:
+            targetPort: 8971
+    ingress:
+      main:
+        enabled: true
+        annotations:    
+          homer.service.name: Monitoring
+          homer.item.logo: ""
+        hosts:
+          - host: frigate.{{ .Values.fqdn }}
+            paths:
+              - path: /
+        tls:
+          - secretName: "{{ .Values.fqdn }}-tls"
+            hosts:
+              - frigate.{{ .Values.fqdn }}
+{{- end }}

--- a/charts/services/templates/frigate.yaml
+++ b/charts/services/templates/frigate.yaml
@@ -10,8 +10,6 @@
 #   # Camera RTSP credentials (for Dahua/EmpireTech cameras)
 #   rtsp-user: "admin"
 #   rtsp-password: "your_camera_password"
-#   # MQTT credentials (if using authenticated MQTT)
-#   mqtt-password: "your_mqtt_password"
 
 ---
 apiVersion: helm.cattle.io/v1
@@ -50,7 +48,6 @@ spec:
             {{- end }}
           {{- end }}
           {{- end }}
-      
       {{- with $frigateConfig.detectors }}
       detectors:
         {{- toYaml . | nindent 8 }}
@@ -128,12 +125,10 @@ spec:
           retain:
             days: {{ $frigateConfig.record.detections_retain_days | default 30 }}
             mode: {{ $frigateConfig.record.retain_mode | default "motion" }}
-      
       snapshots:
         enabled: {{ $frigateConfig.snapshots.enabled | default true }}
         retain:
           default: {{ $frigateConfig.snapshots.retain_days | default 30 }}
-      
       cameras:
         {{- range $name, $cam := $frigateConfig.cameras }}
         {{- with $cam }}
@@ -224,16 +219,6 @@ spec:
               env:
                 {{- if and (empty $frigateConfig.detectors) (eq $gpuVendor "nvidia") }}
                 YOLO_MODELS: yolov7-320
-                {{- end }}
-                {{- with $frigateConfig.mqtt }}
-                {{- with .user }}
-                FRIGATE_MQTT_USER: {{ . | quote }}
-                FRIGATE_MQTT_PASSWORD:
-                  secretKeyRef:
-                    name: frigate-credentials
-                    key: mqtt-password
-                    expandObjectName: false
-                {{- end }}
                 {{- end }}
                 FRIGATE_RTSP_USER:
                   secretKeyRef:

--- a/charts/services/templates/frigate.yaml
+++ b/charts/services/templates/frigate.yaml
@@ -166,7 +166,6 @@ spec:
             password: "{FRIGATE_RTSP_PASSWORD}"
           {{- end }}
         {{- end }}
-    
     workload:
       main:
         annotations:

--- a/charts/services/templates/frigate.yaml
+++ b/charts/services/templates/frigate.yaml
@@ -25,7 +25,7 @@ spec:
   targetNamespace: "{{ .Values.applicationsNamespace }}"
   valuesContent: |-
     image: 
-      tag: 0.17.0-rc1
+      tag: 0.17.1
     {{- $frigateConfig := .Values.applications.frigate }}
     frigateConfig:
       tls:

--- a/charts/services/templates/frigate.yaml
+++ b/charts/services/templates/frigate.yaml
@@ -251,7 +251,7 @@ spec:
         existingClaim: nfs-{{ $frigateConfig.nfs_media }}
         {{- else }}
         storageClass: local-path-persistent-namespaced
-        size: {{ $frigateConfig.media_storage_size | default "100Gi" }}
+        size: 100Gi
         {{- end }}
     global:
       traefik:

--- a/charts/services/templates/frigate.yaml
+++ b/charts/services/templates/frigate.yaml
@@ -21,7 +21,7 @@ metadata:
   namespace: "{{ .Values.applicationsNamespace }}"
 spec:
   chart: oci://oci.trueforge.org/truecharts/frigate
-  version: 19.0.3
+  version: 19.1.1
   targetNamespace: "{{ .Values.applicationsNamespace }}"
   valuesContent: |-
     {{- $frigateConfig := .Values.applications.frigate }}

--- a/charts/services/templates/frigate.yaml
+++ b/charts/services/templates/frigate.yaml
@@ -25,7 +25,7 @@ spec:
   targetNamespace: "{{ .Values.applicationsNamespace }}"
   valuesContent: |-
     image: 
-      tag: 0.17.0-rc2
+      tag: 0.17.0-rc1
     {{- $frigateConfig := .Values.applications.frigate }}
     frigateConfig:
       tls:
@@ -215,7 +215,7 @@ spec:
               resources:
                 requests:
                   memory: 1Gi
-                  cpu: 500m
+                  cpu: 250m
                 limits:
                   memory: 4Gi
                   {{- $gpuVendor := $frigateConfig.gpu_vendor }}

--- a/charts/services/templates/frigate.yaml
+++ b/charts/services/templates/frigate.yaml
@@ -21,11 +21,9 @@ metadata:
   namespace: "{{ .Values.applicationsNamespace }}"
 spec:
   chart: oci://oci.trueforge.org/truecharts/frigate
-  version: 18.15.20
+  version: 19.0.3
   targetNamespace: "{{ .Values.applicationsNamespace }}"
   valuesContent: |-
-    image: 
-      tag: 0.17.1
     {{- $frigateConfig := .Values.applications.frigate }}
     frigateConfig:
       tls:
@@ -87,18 +85,24 @@ spec:
       objects:
         {{- toYaml $frigateConfig.objects | nindent 8 }}
       {{- end }}
+      {{- if $frigateConfig.face_recognition }}
       face_recognition:
-        enabled: true
+        {{- toYaml $frigateConfig.face_recognition | nindent 8 }}
+      {{- end }}
       record:
         enabled: {{ $frigateConfig.record.enabled | default true }}
-        continuous: # TODO REMOVE, should only be in inventory
-          days: {{ $frigateConfig.record.retain_days | default 7 }}
+        continuous:
+          days: {{ $frigateConfig.record.continuous_days | default 0 }}
+        motion:
+          days: {{ $frigateConfig.record.motion_days | default 7 }}
         alerts:
           retain:
             days: {{ $frigateConfig.record.alerts_retain_days | default 30 }}
+            mode: {{ $frigateConfig.record.retain_mode | default "motion" }}
         detections:
           retain:
             days: {{ $frigateConfig.record.detections_retain_days | default 30 }}
+            mode: {{ $frigateConfig.record.retain_mode | default "motion" }}
       
       snapshots:
         enabled: {{ $frigateConfig.snapshots.enabled | default true }}

--- a/charts/services/templates/frigate.yaml
+++ b/charts/services/templates/frigate.yaml
@@ -76,7 +76,7 @@ spec:
         hwaccel_args: preset-nvidia
       {{- else if eq $gpuVendor "amd" }}
       ffmpeg:
-        hwaccel_args: preset-nvidia-h264
+        hwaccel_args: preset-vaapi
       {{- end }}
       {{- with $frigateConfig.motion }}
       motion:

--- a/charts/services/templates/frigate.yaml
+++ b/charts/services/templates/frigate.yaml
@@ -30,7 +30,6 @@ spec:
         enabled: false
       mqtt:
         enabled: false
-      # go2rtc configuration for better live view streaming
       go2rtc:
         streams:
           {{- range $name, $cam := $frigateConfig.cameras }}
@@ -39,14 +38,12 @@ spec:
             {{- if $cam.rtsp_url }}
             - {{ $cam.rtsp_url | quote }}
             {{- else }}
-            # Main stream for high quality live view
             - "rtsp://{FRIGATE_RTSP_USER}:{FRIGATE_RTSP_PASSWORD}@{{ $cam.ip }}/cam/realmonitor?channel={{ $cam.channel | default 1 }}&subtype=0"
             {{- end }}
           {{ $name }}_sub:
             {{- if $cam.rtsp_url_sub }}
             - {{ $cam.rtsp_url_sub | quote }}
             {{- else }}
-            # Sub stream for detection
             - "rtsp://{FRIGATE_RTSP_USER}:{FRIGATE_RTSP_PASSWORD}@{{ $cam.ip }}/cam/realmonitor?channel={{ $cam.channel | default 1 }}&subtype=1"
             {{- end }}
           {{- end }}
@@ -136,13 +133,10 @@ spec:
                   - detect
                   - record
               {{- else }}
-              # Dahua/EmpireTech camera RTSP format
-              # Main stream (high quality for recording) - via go2rtc restream
               - path: "rtsp://127.0.0.1:8554/{{ $name }}"
                 input_args: preset-rtsp-restream
                 roles:
                   - record
-              # Sub stream (lower quality for detection - uses less CPU) - via go2rtc restream
               - path: "rtsp://127.0.0.1:8554/{{ $name }}_sub"
                 input_args: preset-rtsp-restream
                 roles:

--- a/charts/services/templates/frigate.yaml
+++ b/charts/services/templates/frigate.yaml
@@ -25,6 +25,7 @@ spec:
   targetNamespace: "{{ .Values.applicationsNamespace }}"
   valuesContent: |-
     {{- $frigateConfig := .Values.applications.frigate }}
+    {{- $gpuVendor := dig "gpu_vendor" "" $frigateConfig }}
     frigateConfig:
       tls:
         enabled: false
@@ -64,13 +65,16 @@ spec:
         input_pixel_format: bgr
         path: /openvino-model/ssdlite_mobilenet_v2.xml
         labelmap_path: /openvino-model/coco_91cl_bkgr.txt
-      {{- if eq $frigateConfig.gpu_vendor "intel" }}
+      {{- if eq $gpuVendor "intel" }}
       ffmpeg:
         hwaccel_args: preset-vaapi
-      {{- else if eq $frigateConfig.gpu_vendor "intel_xe" }}
+      {{- else if eq $gpuVendor "intel_xe" }}
       ffmpeg:
         hwaccel_args: preset-vaapi
-      {{- else if eq $frigateConfig.gpu_vendor "nvidia" }}
+      {{- else if eq $gpuVendor "nvidia" }}
+      ffmpeg:
+        hwaccel_args: preset-nvidia
+      {{- else if eq $gpuVendor "amd" }}
       ffmpeg:
         hwaccel_args: preset-nvidia-h264
       {{- end }}
@@ -215,7 +219,6 @@ spec:
                   cpu: 250m
                 limits:
                   memory: 4Gi
-                  {{- $gpuVendor := $frigateConfig.gpu_vendor }}
                   {{- if eq $gpuVendor "intel" }}
                     {{- if not $.Values.applications.intel_gpu.enabled }}
                       {{- fail "Intel GPU is selected for Frigate but intel_gpu is not enabled" }}

--- a/charts/services/templates/frigate.yaml
+++ b/charts/services/templates/frigate.yaml
@@ -50,9 +50,9 @@ spec:
           {{- end }}
           {{- end }}
       
-      {{- if $frigateConfig.detectors }}
+      {{- with $frigateConfig.detectors }}
       detectors:
-        {{- toYaml $frigateConfig.detectors | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- else }}
       detectors:
         cpu1:
@@ -78,17 +78,17 @@ spec:
       ffmpeg:
         hwaccel_args: preset-nvidia-h264
       {{- end }}
-      {{- if $frigateConfig.motion }}
+      {{- with $frigateConfig.motion }}
       motion:
-        {{- toYaml $frigateConfig.motion | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if $frigateConfig.objects }}
+      {{- with $frigateConfig.objects }}
       objects:
-        {{- toYaml $frigateConfig.objects | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if $frigateConfig.face_recognition }}
+      {{- with $frigateConfig.face_recognition }}
       face_recognition:
-        {{- toYaml $frigateConfig.face_recognition | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       record:
         enabled: {{ $frigateConfig.record.enabled | default true }}
@@ -193,9 +193,9 @@ spec:
                   path: /api/
                   port: 5000
               env:
-                {{- if $frigateConfig.mqtt }}
-                {{- if $frigateConfig.mqtt.user }}
-                FRIGATE_MQTT_USER: {{ $frigateConfig.mqtt.user | quote }}
+                {{- with $frigateConfig.mqtt }}
+                {{- with .user }}
+                FRIGATE_MQTT_USER: {{ . | quote }}
                 FRIGATE_MQTT_PASSWORD:
                   secretKeyRef:
                     name: frigate-credentials
@@ -249,8 +249,8 @@ spec:
         size: 1Gi
       media:
         enabled: true
-        {{- if $frigateConfig.nfs_media }}
-        existingClaim: nfs-{{ $frigateConfig.nfs_media }}
+        {{- with $frigateConfig.nfs_media }}
+        existingClaim: nfs-{{ . }}
         {{- else }}
         storageClass: local-path-persistent-namespaced
         size: 100Gi

--- a/charts/services/templates/frigate.yaml
+++ b/charts/services/templates/frigate.yaml
@@ -53,11 +53,16 @@ spec:
       {{- with $frigateConfig.detectors }}
       detectors:
         {{- toYaml . | nindent 8 }}
-      {{- else }}
-      detectors:
-        cpu1:
-          type: cpu
+      {{- with $frigateConfig.model }}
+      model:
+        {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- else }}
+      {{- if or (eq $gpuVendor "intel") (eq $gpuVendor "intel_xe") }}
+      detectors:
+        ov:
+          type: openvino
+          device: GPU
       model:
         width: 300
         height: 300
@@ -65,6 +70,24 @@ spec:
         input_pixel_format: bgr
         path: /openvino-model/ssdlite_mobilenet_v2.xml
         labelmap_path: /openvino-model/coco_91cl_bkgr.txt
+      {{- else if eq $gpuVendor "nvidia" }}
+      detectors:
+        tensorrt:
+          type: tensorrt
+          device: 0
+      model:
+        path: /config/model_cache/tensorrt/yolov7-320.trt
+        labelmap_path: /labelmap/coco-80.txt
+        input_tensor: nchw
+        input_pixel_format: rgb
+        width: 320
+        height: 320
+      {{- else }}
+      detectors:
+        cpu1:
+          type: cpu
+      {{- end }}
+      {{- end }}
       {{- if eq $gpuVendor "intel" }}
       ffmpeg:
         hwaccel_args: preset-vaapi
@@ -181,6 +204,9 @@ spec:
             backup.velero.io/backup-volumes: config
           containers:
             main:
+              {{- if eq $gpuVendor "nvidia" }}
+              imageSelector: tensorrtImage
+              {{- end }}
               probes:
                 liveness:
                   type: http
@@ -195,6 +221,9 @@ spec:
                   path: /api/
                   port: 5000
               env:
+                {{- if and (empty $frigateConfig.detectors) (eq $gpuVendor "nvidia") }}
+                YOLO_MODELS: yolov7-320
+                {{- end }}
                 {{- with $frigateConfig.mqtt }}
                 {{- with .user }}
                 FRIGATE_MQTT_USER: {{ . | quote }}

--- a/charts/services/templates/frigate.yaml
+++ b/charts/services/templates/frigate.yaml
@@ -23,7 +23,8 @@ spec:
   chart: oci://oci.trueforge.org/truecharts/frigate
   version: 19.1.1
   targetNamespace: "{{ .Values.applicationsNamespace }}"
-  valuesContent: |-
+  # default-values: https://github.com/trueforge-org/truecharts/blob/master/charts/stable/frigate/values.yaml
+  values:
     {{- $frigateConfig := .Values.applications.frigate }}
     {{- $gpuVendor := dig "gpu_vendor" "" $frigateConfig }}
     frigateConfig:

--- a/charts/services/templates/frigate.yaml
+++ b/charts/services/templates/frigate.yaml
@@ -36,14 +36,14 @@ spec:
           {{- range $name, $cam := $frigateConfig.cameras }}
           {{- if $cam.enabled | default true }}
           {{ $name }}:
-            {{- if $cam.rtsp_url }}
-            - {{ $cam.rtsp_url | quote }}
+            {{- with $cam.rtsp_url }}
+            - {{ . | quote }}
             {{- else }}
             - "rtsp://{FRIGATE_RTSP_USER}:{FRIGATE_RTSP_PASSWORD}@{{ $cam.ip }}/cam/realmonitor?channel={{ $cam.channel | default 1 }}&subtype=0"
             {{- end }}
           {{ $name }}_sub:
-            {{- if $cam.rtsp_url_sub }}
-            - {{ $cam.rtsp_url_sub | quote }}
+            {{- with $cam.rtsp_url_sub }}
+            - {{ . | quote }}
             {{- else }}
             - "rtsp://{FRIGATE_RTSP_USER}:{FRIGATE_RTSP_PASSWORD}@{{ $cam.ip }}/cam/realmonitor?channel={{ $cam.channel | default 1 }}&subtype=1"
             {{- end }}
@@ -112,18 +112,19 @@ spec:
       
       cameras:
         {{- range $name, $cam := $frigateConfig.cameras }}
+        {{- with $cam }}
         {{ $name }}:
-          enabled: {{ $cam.enabled | default true }}
-          {{- if $cam.detect }}
+          enabled: {{ .enabled | default true }}
+          {{- with .detect }}
           detect:
             enabled: true
-            {{- if $cam.detect.width }}
-            width: {{ $cam.detect.width }}
+            {{- with .width }}
+            width: {{ . }}
             {{- end }}
-            {{- if $cam.detect.height }}
-            height: {{ $cam.detect.height }}
+            {{- with .height }}
+            height: {{ . }}
             {{- end }}
-            fps: {{ $cam.detect.fps | default 10 }}
+            fps: {{ .fps | default 10 }}
           {{- else }}
           detect:
             enabled: true
@@ -131,8 +132,8 @@ spec:
           {{- end }}
           ffmpeg:
             inputs:
-              {{- if $cam.rtsp_url }}
-              - path: {{ $cam.rtsp_url | quote }}
+              {{- with .rtsp_url }}
+              - path: {{ . | quote }}
                 roles:
                   - detect
                   - record
@@ -146,29 +147,30 @@ spec:
                 roles:
                   - detect
               {{- end }}
-          {{- if $cam.live }}
+          {{- with .live }}
           live:
-            {{- toYaml $cam.live | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- if $cam.motion }}
+          {{- with .motion }}
           motion:
-            {{- toYaml $cam.motion | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- if $cam.zones }}
+          {{- with .zones }}
           zones:
-            {{- toYaml $cam.zones | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- if $cam.objects }}
+          {{- with .objects }}
           objects:
-            {{- toYaml $cam.objects | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- if $cam.onvif }}
+          {{- with .onvif }}
           onvif:
             host: {{ $cam.ip }}
-            port: {{ $cam.onvif.port | default 80 }}
+            port: {{ .port | default 80 }}
             user: "{FRIGATE_RTSP_USER}"
             password: "{FRIGATE_RTSP_PASSWORD}"
           {{- end }}
+        {{- end }}
         {{- end }}
     workload:
       main:

--- a/charts/services/templates/frigate.yaml
+++ b/charts/services/templates/frigate.yaml
@@ -1,16 +1,5 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.frigate.enabled }}
-# ---
-# apiVersion: v1
-# kind: Secret
-# metadata:
-#   name: frigate-credentials
-#   namespace: "{{ .Values.applicationsNamespace }}"
-# type: Opaque
-# stringData:
-#   # Camera RTSP credentials (for Dahua/EmpireTech cameras)
-#   rtsp-user: "admin"
-#   rtsp-password: "your_camera_password"
-
+{{- if (include "app.enabled" (list . "frigate")) }}
+{{- $gpuVendor := dig "gpu_vendor" "" (.Values.applications.frigate | default dict) -}}
 ---
 apiVersion: helm.cattle.io/v1
 kind: HelmChart
@@ -19,43 +8,16 @@ metadata:
   namespace: "{{ .Values.applicationsNamespace }}"
 spec:
   chart: oci://oci.trueforge.org/truecharts/frigate
-  version: 19.1.1
+  version: 19.4.0
   targetNamespace: "{{ .Values.applicationsNamespace }}"
   # default-values: https://github.com/trueforge-org/truecharts/blob/master/charts/stable/frigate/values.yaml
   values:
-    {{- $frigateConfig := .Values.applications.frigate }}
-    {{- $gpuVendor := dig "gpu_vendor" "" $frigateConfig }}
+    {{- $gpuVendor := .Values.applications.frigate.gpu_vendor }}
     frigateConfig:
       tls:
         enabled: false
       mqtt:
         enabled: false
-      go2rtc:
-        streams:
-          {{- range $name, $cam := $frigateConfig.cameras }}
-          {{- if $cam.enabled | default true }}
-          {{ $name }}:
-            {{- with $cam.rtsp_url }}
-            - {{ . | quote }}
-            {{- else }}
-            - "rtsp://{FRIGATE_RTSP_USER}:{FRIGATE_RTSP_PASSWORD}@{{ $cam.ip }}/cam/realmonitor?channel={{ $cam.channel | default 1 }}&subtype=0"
-            {{- end }}
-          {{ $name }}_sub:
-            {{- with $cam.rtsp_url_sub }}
-            - {{ . | quote }}
-            {{- else }}
-            - "rtsp://{FRIGATE_RTSP_USER}:{FRIGATE_RTSP_PASSWORD}@{{ $cam.ip }}/cam/realmonitor?channel={{ $cam.channel | default 1 }}&subtype=1"
-            {{- end }}
-          {{- end }}
-          {{- end }}
-      {{- with $frigateConfig.detectors }}
-      detectors:
-        {{- toYaml . | nindent 8 }}
-      {{- with $frigateConfig.model }}
-      model:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- else }}
       {{- if or (eq $gpuVendor "intel") (eq $gpuVendor "intel_xe") }}
       detectors:
         ov:
@@ -85,117 +47,19 @@ spec:
         cpu1:
           type: cpu
       {{- end }}
-      {{- end }}
-      {{- if eq $gpuVendor "intel" }}
-      ffmpeg:
-        hwaccel_args: preset-vaapi
-      {{- else if eq $gpuVendor "intel_xe" }}
-      ffmpeg:
-        hwaccel_args: preset-vaapi
-      {{- else if eq $gpuVendor "nvidia" }}
+      {{- if eq $gpuVendor "nvidia" }}
       ffmpeg:
         hwaccel_args: preset-nvidia
-      {{- else if eq $gpuVendor "amd" }}
+      {{- else if $gpuVendor }}
       ffmpeg:
         hwaccel_args: preset-vaapi
       {{- end }}
-      {{- with $frigateConfig.motion }}
-      motion:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with $frigateConfig.objects }}
-      objects:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with $frigateConfig.face_recognition }}
-      face_recognition:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      record:
-        enabled: {{ $frigateConfig.record.enabled | default true }}
-        continuous:
-          days: {{ $frigateConfig.record.continuous_days | default 0 }}
-        motion:
-          days: {{ $frigateConfig.record.motion_days | default 7 }}
-        alerts:
-          retain:
-            days: {{ $frigateConfig.record.alerts_retain_days | default 30 }}
-            mode: {{ $frigateConfig.record.retain_mode | default "motion" }}
-        detections:
-          retain:
-            days: {{ $frigateConfig.record.detections_retain_days | default 30 }}
-            mode: {{ $frigateConfig.record.retain_mode | default "motion" }}
-      snapshots:
-        enabled: {{ $frigateConfig.snapshots.enabled | default true }}
-        retain:
-          default: {{ $frigateConfig.snapshots.retain_days | default 30 }}
-      cameras:
-        {{- range $name, $cam := $frigateConfig.cameras }}
-        {{- with $cam }}
-        {{ $name }}:
-          enabled: {{ .enabled | default true }}
-          {{- with .detect }}
-          detect:
-            enabled: true
-            {{- with .width }}
-            width: {{ . }}
-            {{- end }}
-            {{- with .height }}
-            height: {{ . }}
-            {{- end }}
-            fps: {{ .fps | default 10 }}
-          {{- else }}
-          detect:
-            enabled: true
-            fps: 10
-          {{- end }}
-          ffmpeg:
-            inputs:
-              {{- with .rtsp_url }}
-              - path: {{ . | quote }}
-                roles:
-                  - detect
-                  - record
-              {{- else }}
-              - path: "rtsp://127.0.0.1:8554/{{ $name }}"
-                input_args: preset-rtsp-restream
-                roles:
-                  - record
-              - path: "rtsp://127.0.0.1:8554/{{ $name }}_sub"
-                input_args: preset-rtsp-restream
-                roles:
-                  - detect
-              {{- end }}
-          {{- with .live }}
-          live:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          {{- with .motion }}
-          motion:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          {{- with .zones }}
-          zones:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          {{- with .objects }}
-          objects:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          {{- with .onvif }}
-          onvif:
-            host: {{ $cam.ip }}
-            port: {{ .port | default 80 }}
-            user: "{FRIGATE_RTSP_USER}"
-            password: "{FRIGATE_RTSP_PASSWORD}"
-          {{- end }}
-        {{- end }}
-        {{- end }}
     workload:
       main:
-        annotations:
-          reloader.stakater.com/auto: "true"
         podSpec:
+          nodeSelector:
+            # Schedule only on NAS nodes
+            nas: "true"
           annotations:
             backup.velero.io/backup-volumes: config
           containers:
@@ -217,61 +81,39 @@ spec:
                   path: /api/
                   port: 5000
               env:
-                {{- if and (empty $frigateConfig.detectors) (eq $gpuVendor "nvidia") }}
+                {{- if (eq $gpuVendor "nvidia") }}
                 YOLO_MODELS: yolov7-320
                 {{- end }}
-                FRIGATE_RTSP_USER:
-                  secretKeyRef:
-                    name: frigate-credentials
-                    key: rtsp-user
-                    expandObjectName: false
-                FRIGATE_RTSP_PASSWORD:
-                  secretKeyRef:
-                    name: frigate-credentials
-                    key: rtsp-password
-                    expandObjectName: false
               resources:
                 requests:
                   memory: 1Gi
                   cpu: 250m
                 limits:
+                  cpu: null
                   memory: 4Gi
                   {{- if eq $gpuVendor "intel" }}
-                    {{- if not $.Values.applications.intel_gpu.enabled }}
+                    {{- if not (include "app.enabled" (list . "intel_gpu")) }}
                       {{- fail "Intel GPU is selected for Frigate but intel_gpu is not enabled" }}
                     {{- end }}
                   gpu.intel.com/i915: 1
                   {{- else if eq $gpuVendor "intel_xe" }}
-                    {{- if not $.Values.applications.intel_gpu.enabled }}
+                    {{- if not (include "app.enabled" (list . "intel_gpu")) }}
                       {{- fail "Intel GPU is selected for Frigate but intel_gpu is not enabled" }}
                     {{- end }}
                   gpu.intel.com/xe: 1
                   {{- else if eq $gpuVendor "nvidia" }}
-                    {{- if not $.Values.applications.nvidia_gpu.enabled }}
+                    {{- if not (include "app.enabled" (list . "nvidia_gpu")) }}
                       {{- fail "NVIDIA GPU is selected for Frigate but nvidia_gpu is not enabled" }}
                     {{- end }}
                   nvidia.com/gpu: 1
                   {{- else if eq $gpuVendor "amd" }}
-                    {{- if not $.Values.applications.amd_gpu.enabled }}
+                    {{- if not (include "app.enabled" (list . "amd_gpu")) }}
                       {{- fail "AMD GPU is selected for Frigate but amd_gpu is not enabled" }}
                     {{- end }}
                   amd.com/gpu: 1
                   {{- else if $gpuVendor }}
                     {{- fail (printf "Unknown GPU vendor '%s' selected for Frigate" $gpuVendor) }}
                   {{- end }}
-    persistence:
-      config:
-        enabled: true
-        storageClass: local-path-persistent-namespaced
-        size: 1Gi
-      media:
-        enabled: true
-        {{- with $frigateConfig.nfs_media }}
-        existingClaim: nfs-{{ . }}
-        {{- else }}
-        storageClass: local-path-persistent-namespaced
-        size: 100Gi
-        {{- end }}
     global:
       traefik:
         fixedMiddlewares: []
@@ -283,9 +125,9 @@ spec:
     ingress:
       main:
         enabled: true
-        annotations:    
+        annotations:
           homer.service.name: Monitoring
-          homer.item.logo: ""
+          homer.item.logo: "https://raw.githubusercontent.com/blakeblackshear/frigate/37ea6b46b51e459a51f25f29fead2797e0fa04a4/docs/static/img/branding/logo.svg"
         hosts:
           - host: frigate.{{ .Values.fqdn }}
             paths:
@@ -294,4 +136,13 @@ spec:
           - secretName: "{{ .Values.fqdn }}-tls"
             hosts:
               - frigate.{{ .Values.fqdn }}
+    persistence:
+      config:
+        enabled: true
+        storageClass: local-path-persistent-namespaced
+        size: 1Gi
+      media:
+        enabled: true
+        existingClaim: multimedia
+        subPath: CCTV
 {{- end }}

--- a/charts/services/templates/frigate.yaml
+++ b/charts/services/templates/frigate.yaml
@@ -18,6 +18,7 @@ spec:
         enabled: false
       mqtt:
         enabled: false
+      cameras: {}
       {{- if or (eq $gpuVendor "intel") (eq $gpuVendor "intel_xe") }}
       detectors:
         ov:

--- a/charts/services/templates/frigate.yaml
+++ b/charts/services/templates/frigate.yaml
@@ -13,48 +13,6 @@ spec:
   # default-values: https://github.com/trueforge-org/truecharts/blob/master/charts/stable/frigate/values.yaml
   values:
     {{- $gpuVendor := .Values.applications.frigate.gpu_vendor }}
-    frigateConfig:
-      tls:
-        enabled: false
-      mqtt:
-        enabled: false
-      cameras: {}
-      {{- if or (eq $gpuVendor "intel") (eq $gpuVendor "intel_xe") }}
-      detectors:
-        ov:
-          type: openvino
-          device: GPU
-      model:
-        width: 300
-        height: 300
-        input_tensor: nhwc
-        input_pixel_format: bgr
-        path: /openvino-model/ssdlite_mobilenet_v2.xml
-        labelmap_path: /openvino-model/coco_91cl_bkgr.txt
-      {{- else if eq $gpuVendor "nvidia" }}
-      detectors:
-        tensorrt:
-          type: tensorrt
-          device: 0
-      model:
-        path: /config/model_cache/tensorrt/yolov7-320.trt
-        labelmap_path: /labelmap/coco-80.txt
-        input_tensor: nchw
-        input_pixel_format: rgb
-        width: 320
-        height: 320
-      {{- else }}
-      detectors:
-        cpu1:
-          type: cpu
-      {{- end }}
-      {{- if eq $gpuVendor "nvidia" }}
-      ffmpeg:
-        hwaccel_args: preset-nvidia
-      {{- else if $gpuVendor }}
-      ffmpeg:
-        hwaccel_args: preset-vaapi
-      {{- end }}
     workload:
       main:
         podSpec:
@@ -63,6 +21,21 @@ spec:
             nas: "true"
           annotations:
             backup.velero.io/backup-volumes: config
+          initContainers:
+            init-config:
+              enabled: true
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  mkdir -p /config
+                  if [ ! -f /config/config.yml ]; then
+                    echo "Config file not found, copying initial config..."
+                    cp /initial-config/config.yml /config/config.yml
+                    echo "Config file copied, you can now edit it at /config/config.yml"
+                  else
+                    echo "Config file found, you can edit it at /config/config.yml"
+                  fi
           containers:
             main:
               {{- if eq $gpuVendor "nvidia" }}
@@ -137,7 +110,63 @@ spec:
           - secretName: "{{ .Values.fqdn }}-tls"
             hosts:
               - frigate.{{ .Values.fqdn }}
+    configmap:
+      initial-config:
+        enabled: true
+        data:
+          config.yml: |-
+            tls:
+              enabled: false
+            mqtt:
+              enabled: false
+            cameras: {}
+            {{- if or (eq $gpuVendor "intel") (eq $gpuVendor "intel_xe") }}
+            detectors:
+              ov:
+                type: openvino
+                device: GPU
+            model:
+              width: 300
+              height: 300
+              input_tensor: nhwc
+              input_pixel_format: bgr
+              path: /openvino-model/ssdlite_mobilenet_v2.xml
+              labelmap_path: /openvino-model/coco_91cl_bkgr.txt
+            {{- else if eq $gpuVendor "nvidia" }}
+            detectors:
+              tensorrt:
+                type: tensorrt
+                device: 0
+            model:
+              path: /config/model_cache/tensorrt/yolov7-320.trt
+              labelmap_path: /labelmap/coco-80.txt
+              input_tensor: nchw
+              input_pixel_format: rgb
+              width: 320
+              height: 320
+            {{- else }}
+            detectors:
+              cpu1:
+                type: cpu
+            {{- end }}
+            {{- if eq $gpuVendor "nvidia" }}
+            ffmpeg:
+              hwaccel_args: preset-nvidia
+            {{- else if $gpuVendor }}
+            ffmpeg:
+              hwaccel_args: preset-vaapi
+            {{- end }}
     persistence:
+      initial-config:
+        enabled: true
+        type: configmap
+        objectName: initial-config
+        targetSelector:
+          main:
+            init-config:
+              subPath: config.yml
+              mountPath: /initial-config/config.yml
+              readOnly: true
       config:
         enabled: true
         storageClass: local-path-persistent-namespaced

--- a/charts/services/values.yaml
+++ b/charts/services/values.yaml
@@ -100,6 +100,30 @@ applications:
     enabled: true
   flaresolverr:
     enabled: true
+  frigate:
+    enabled: true
+    # gpu_vendor: intel
+    # media_storage_size: 100Gi
+    record:
+      enabled: true
+      retain_mode: motion
+      continuous_days: 0
+      motion_days: 7
+      alerts_retain_days: 30
+      detections_retain_days: 30
+    snapshots:
+      enabled: true
+      retain_days: 30
+    cameras: {}
+    # cameras:
+    #   front_camera:
+    #     enabled: true
+    #     ip: 192.168.1.100
+    #     channel: 1
+    #     detect:
+    #       width: 1280
+    #       height: 720
+    #       fps: 10
   gluetun:
     enabled: true
   gotify:

--- a/charts/services/values.yaml
+++ b/charts/services/values.yaml
@@ -103,6 +103,8 @@ applications:
   frigate:
     enabled: true
     # gpu_vendor: intel
+    # detectors: {} # optional manual override for detector backends like AMD/ROCm, Coral, Hailo, etc.
+    # model: {} # optional model configuration paired with custom detectors
     record:
       enabled: true
       retain_mode: motion

--- a/charts/services/values.yaml
+++ b/charts/services/values.yaml
@@ -103,7 +103,6 @@ applications:
   frigate:
     enabled: true
     # gpu_vendor: intel
-    # media_storage_size: 100Gi
     record:
       enabled: true
       retain_mode: motion

--- a/charts/services/values.yaml
+++ b/charts/services/values.yaml
@@ -103,6 +103,30 @@ applications:
   #   enabled: true
   flaresolverr: {}
   #   enabled: true
+  frigate:
+    # enabled: true
+    # gpu_vendor: intel
+    # media_storage_size: 100Gi
+    record:
+      enabled: true
+      retain_mode: motion
+      continuous_days: 0
+      motion_days: 7
+      alerts_retain_days: 30
+      detections_retain_days: 30
+    snapshots:
+      enabled: true
+      retain_days: 30
+    cameras: {}
+    # cameras:
+    #   front_camera:
+    #     enabled: true
+    #     ip: 192.168.1.100
+    #     channel: 1
+    #     detect:
+    #       width: 1280
+    #       height: 720
+    #       fps: 10
   gluetun: {}
   #   enabled: true
   gotify: {}

--- a/charts/services/values.yaml
+++ b/charts/services/values.yaml
@@ -103,31 +103,9 @@ applications:
   #   enabled: true
   flaresolverr: {}
   #   enabled: true
-  frigate:
-    # enabled: true
-    # gpu_vendor: intel
-    # detectors: {} # optional manual override for detector backends like AMD/ROCm, Coral, Hailo, etc.
-    # model: {} # optional model configuration paired with custom detectors
-    record:
-      enabled: true
-      retain_mode: motion
-      continuous_days: 0
-      motion_days: 7
-      alerts_retain_days: 30
-      detections_retain_days: 30
-    snapshots:
-      enabled: true
-      retain_days: 30
-    cameras: {}
-    # cameras:
-    #   front_camera:
-    #     enabled: true
-    #     ip: 192.168.1.100
-    #     channel: 1
-    #     detect:
-    #       width: 1280
-    #       height: 720
-    #       fps: 10
+  frigate: {}
+  #   enabled: true
+  #   gpu_vendor: intel
   gluetun: {}
   #   enabled: true
   gotify: {}

--- a/charts/services/values.yaml
+++ b/charts/services/values.yaml
@@ -106,7 +106,6 @@ applications:
   frigate:
     # enabled: true
     # gpu_vendor: intel
-    # media_storage_size: 100Gi
     record:
       enabled: true
       retain_mode: motion

--- a/charts/services/values.yaml
+++ b/charts/services/values.yaml
@@ -106,6 +106,8 @@ applications:
   frigate:
     # enabled: true
     # gpu_vendor: intel
+    # detectors: {} # optional manual override for detector backends like AMD/ROCm, Coral, Hailo, etc.
+    # model: {} # optional model configuration paired with custom detectors
     record:
       enabled: true
       retain_mode: motion


### PR DESCRIPTION
## Features

- Camera configuration via inventory : supports RTSP cameras with go2rtc re-streaming (main stream for recording, sub stream for detection)
- GPU acceleration:  Tested on Intel Xe with an Intel Arc B580 but it should also work with intel non-xe, NVIDIA and AMD.
- OpenVINO object detection: defaults to SSDLite MobileNet v2 with configurable detectors (CPU, OpenVINO GPU, etc.)
- Recording: configurable continuous, motion-based, alert, and detection retention
- Passthrough config: motion masks, object masks/filters, face recognition, zones, and ONVIF passed through via `toYaml`
- Storage: local persistent volumes or NFS for media
- Optional MQTT with credentials via Kubernetes secrets
- Traefik ingress with TLS and Homer dashboard integration

## Changes

- `charts/services/templates/frigate.yaml` : new Helm template
- `charts/services/values.yaml` : default values for the frigate application