### PR TITLE
Disable kubeApiServer scraper to avoid duplicating metrics

### DIFF
--- a/charts/services/templates/prometheus.yaml
+++ b/charts/services/templates/prometheus.yaml
@@ -404,7 +404,12 @@ spec:
         enabled: false
       serviceMonitor:
         enabled: false
-    # Disable community scrapers and let pushprox scrape metrics instead for k3s
+    kubeApiServer:
+      jobNameOverride: k3s-server
+      service:
+        enabled: false
+      serviceMonitor:
+        enabled: false
     kubeControllerManager:
       jobNameOverride: k3s-server
       service:


### PR DESCRIPTION
The `k3s-server` PushProx job already scrapes the full apiserver metrics from each control-plane node via `/metrics`. The separate `apiserver` ServiceMonitor scrapes the exact same endpoint directly at port 6443.

**Proof — identical sample counts per node:**

| Node | `k3s-server /metrics` | `apiserver` job | |---|---|---|
| descartes | 78,754 | 78,754 |
| aristotle | 62,156 | 62,156 |
| aurelius | 56,219 | 56,219 |

197,129 samples are scraped twice every cycle (every 15s). This also doubles the cardinality of every apiserver histogram — `apiserver_request_duration_seconds_bucket` alone has 63,036 series, half of which are duplicates.