### PR TITLE
Replace disableAllApplications with enableAllApplicationsByDefault

### DIFF
--- a/charts/services/templates/_helpers.tpl
+++ b/charts/services/templates/_helpers.tpl
@@ -1,5 +1,16 @@
+{{- define "app.enabled" -}}
+{{- $root := index . 0 -}}
+{{- $appKey := index . 1 -}}
+{{- $app := index $root.Values.applications $appKey | default dict -}}
+{{- if hasKey $app "enabled" -}}
+{{- ternary "true" "" $app.enabled -}}
+{{- else -}}
+{{- ternary "true" "" $root.Values.enableAllApplicationsByDefault -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "metrics.enabled" -}}
-{{- and (not .Values.disableAllApplications) .Values.applications.prometheus.enabled | ternary "true" "" -}}
+{{- include "app.enabled" (list . "prometheus") -}}
 {{- end -}}
 
 {{- define "ldap.base_dn" -}}

--- a/charts/services/templates/_helpers.tpl
+++ b/charts/services/templates/_helpers.tpl
@@ -1,5 +1,11 @@
+{{- define "app.enabled" -}}
+{{- $scope := index . 0 -}}
+{{- $app := index . 1 -}}
+{{- dig $app "enabled" $scope.Values.enableAllApplicationsByDefault $scope.Values.applications | ternary "true" "" -}}
+{{- end -}}
+
 {{- define "metrics.enabled" -}}
-{{- and (not .Values.disableAllApplications) .Values.applications.prometheus.enabled | ternary "true" "" -}}
+{{- include "app.enabled" (list . "prometheus") -}}
 {{- end -}}
 
 {{- define "ldap.base_dn" -}}

--- a/charts/services/templates/akri.yaml
+++ b/charts/services/templates/akri.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.primaryTenant (not .Values.disableAllApplications) .Values.applications.akri.enabled }}
+{{- if and .Values.primaryTenant (include "app.enabled" (list . "akri")) }}
 ---
 apiVersion: helm.cattle.io/v1
 kind: HelmChart

--- a/charts/services/templates/alloy.yaml
+++ b/charts/services/templates/alloy.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.primaryTenant (not .Values.disableAllApplications) .Values.applications.alloy.enabled }}
+{{- if and .Values.primaryTenant (include "app.enabled" (list . "alloy")) }}
 ---
 apiVersion: helm.cattle.io/v1
 kind: HelmChart
@@ -39,18 +39,18 @@ spec:
             http { endpoint = "0.0.0.0:4318" }
 
             output {
-{{- if .Values.applications.tempo.enabled }}
+{{- if include "app.enabled" (list . "tempo") }}
               traces = [otelcol.exporter.otlp.default.input]
 {{- end }}
-{{- if .Values.applications.prometheus.enabled }}
+{{- if include "app.enabled" (list . "prometheus") }}
               metrics = [otelcol.exporter.prometheus.default.input]
 {{- end }}
-{{- if .Values.applications.loki.enabled }}
+{{- if include "app.enabled" (list . "loki") }}
               logs    = [otelcol.exporter.loki.default.input]
 {{- end }}
             }
           }
-{{- if .Values.applications.prometheus.enabled }}
+{{- if include "app.enabled" (list . "prometheus") }}
           prometheus.remote_write "default" {
             endpoint {
               url = "http://prometheus-operated:9090/api/v1/write"
@@ -61,14 +61,14 @@ spec:
             forward_to = [prometheus.remote_write.default.receiver]
           }
 {{- end }}
-{{- if .Values.applications.tempo.enabled }}
+{{- if include "app.enabled" (list . "tempo") }}
           otelcol.exporter.otlp "default" {
             client {
               endpoint = "tempo:4317"
             }
           }
 {{- end }}
-{{- if .Values.applications.loki.enabled }}
+{{- if include "app.enabled" (list . "loki") }}
           loki.write "default" {
             endpoint {
               url = "http://loki:3100/loki/api/v1/push"

--- a/charts/services/templates/alloy.yaml
+++ b/charts/services/templates/alloy.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.primaryTenant (not .Values.disableAllApplications) .Values.applications.alloy.enabled }}
+{{- if and .Values.primaryTenant (include "app.enabled" (list . "alloy")) }}
 ---
 apiVersion: helm.cattle.io/v1
 kind: HelmChart
@@ -39,18 +39,18 @@ spec:
             http { endpoint = "0.0.0.0:4318" }
 
             output {
-{{- if .Values.applications.tempo.enabled }}
+{{- if (include "app.enabled" (list . "tempo")) }}
               traces = [otelcol.exporter.otlp.default.input]
 {{- end }}
-{{- if .Values.applications.prometheus.enabled }}
+{{- if (include "app.enabled" (list . "prometheus")) }}
               metrics = [otelcol.exporter.prometheus.default.input]
 {{- end }}
-{{- if .Values.applications.loki.enabled }}
+{{- if (include "app.enabled" (list . "loki")) }}
               logs    = [otelcol.exporter.loki.default.input]
 {{- end }}
             }
           }
-{{- if .Values.applications.prometheus.enabled }}
+{{- if (include "app.enabled" (list . "prometheus")) }}
           prometheus.remote_write "default" {
             endpoint {
               url = "http://prometheus-operated:9090/api/v1/write"
@@ -61,14 +61,14 @@ spec:
             forward_to = [prometheus.remote_write.default.receiver]
           }
 {{- end }}
-{{- if .Values.applications.tempo.enabled }}
+{{- if (include "app.enabled" (list . "tempo")) }}
           otelcol.exporter.otlp "default" {
             client {
               endpoint = "tempo:4317"
             }
           }
 {{- end }}
-{{- if .Values.applications.loki.enabled }}
+{{- if (include "app.enabled" (list . "loki")) }}
           loki.write "default" {
             endpoint {
               url = "http://loki:3100/loki/api/v1/push"

--- a/charts/services/templates/amd-gpu.yaml
+++ b/charts/services/templates/amd-gpu.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.primaryTenant (not .Values.disableAllApplications) .Values.applications.amd_gpu.enabled }}
+{{- if and .Values.primaryTenant (include "app.enabled" (list . "amd_gpu")) }}
 ---
 apiVersion: helm.cattle.io/v1
 kind: HelmChart

--- a/charts/services/templates/archivebox.yaml
+++ b/charts/services/templates/archivebox.yaml
@@ -1,4 +1,4 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.archivebox.enabled }}
+{{- if include "app.enabled" (list . "archivebox") }}
 # ---
 # apiVersion: v1
 # kind: Secret

--- a/charts/services/templates/archivebox.yaml
+++ b/charts/services/templates/archivebox.yaml
@@ -1,4 +1,4 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.archivebox.enabled }}
+{{- if (include "app.enabled" (list . "archivebox")) }}
 # ---
 # apiVersion: v1
 # kind: Secret

--- a/charts/services/templates/argo.yaml
+++ b/charts/services/templates/argo.yaml
@@ -1,5 +1,5 @@
-{{- if and .Values.primaryTenant (not .Values.disableAllApplications) .Values.applications.argo.enabled }}
-{{- if not .Values.applications.redis.enabled }}
+{{- if and .Values.primaryTenant (include "app.enabled" (list . "argo")) }}
+{{- if not (include "app.enabled" (list . "redis")) }}
 {{- fail "Argo requires Redis to be enabled. Please enable Redis in your values.yaml" }}
 {{- end }}
 ---

--- a/charts/services/templates/argo.yaml
+++ b/charts/services/templates/argo.yaml
@@ -1,6 +1,6 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.argo.enabled }}
+{{- if (include "app.enabled" (list . "argo")) }}
 {{- if and .Values.primaryTenant }}
-{{- if not .Values.applications.redis.enabled }}
+{{- if not (include "app.enabled" (list . "redis")) }}
 {{- fail "Argo requires Redis to be enabled. Please enable Redis in your values.yaml" }}
 {{- end }}
 ---

--- a/charts/services/templates/authentik.yaml
+++ b/charts/services/templates/authentik.yaml
@@ -1,5 +1,5 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.authentik.enabled }}
-{{- if not .Values.applications.postgresql.enabled }}
+{{- if include "app.enabled" (list . "authentik") }}
+{{- if not (include "app.enabled" (list . "postgresql")) }}
 {{- fail "Authentik requires PostgreSQL to be enabled. Please enable PostgreSQL in your values.yaml" }}
 {{- end }}
 ---
@@ -129,51 +129,51 @@ spec:
         - authentik-ldap-blueprint
         - authentik-extra-blueprints
         - authentik-traefik-forward-auth
-{{- if .Values.applications.home_assistant.enabled }}
+{{- if include "app.enabled" (list . "home_assistant") }}
         - authentik-home-assistant-blueprint
 {{- end }}
-{{- if .Values.applications.immich.enabled }}
+{{- if include "app.enabled" (list . "immich") }}
         - immich-authentik-blueprint
 {{- end }}
-{{- if .Values.applications.minio.enabled }}
+{{- if include "app.enabled" (list . "minio") }}
         - authentik-minio-blueprint
 {{- end }}
-{{- if .Values.applications.nextcloud.enabled }}
+{{- if include "app.enabled" (list . "nextcloud") }}
         - authentik-nextcloud-blueprint
 {{- end }}
-{{- if .Values.applications.odoo.enabled }}
+{{- if include "app.enabled" (list . "odoo") }}
         - odoo-authentik-blueprint
 {{- end }}
-{{- if .Values.applications.open_webui.enabled }}
+{{- if include "app.enabled" (list . "open_webui") }}
         - authentik-open-webui-blueprint
 {{- end }}
-{{- if .Values.applications.stalwart.enabled }}
+{{- if include "app.enabled" (list . "stalwart") }}
         - authentik-stalwart-blueprint
 {{- end }}
-{{- if and .Values.applications.wakapi.enabled (not .Values.applications.wakapi.trusted_header_auth) }}
+{{- if and (include "app.enabled" (list . "wakapi")) (not .Values.applications.wakapi.trusted_header_auth) }}
         - wakapi-authentik-blueprint
 {{- end }}
       secrets:
         - ldap
-{{- if .Values.applications.home_assistant.enabled }}
+{{- if include "app.enabled" (list . "home_assistant") }}
         - home-assistant-oidc
 {{- end }}
-{{- if .Values.applications.immich.enabled }}
+{{- if include "app.enabled" (list . "immich") }}
         - immich
 {{- end }}
-{{- if .Values.applications.minio.enabled }}
+{{- if include "app.enabled" (list . "minio") }}
         - minio-oidc
 {{- end }}
-{{- if .Values.applications.nextcloud.enabled }}
+{{- if include "app.enabled" (list . "nextcloud") }}
         - nextcloud-oidc
 {{- end }}
-{{- if .Values.applications.odoo.enabled }}
+{{- if include "app.enabled" (list . "odoo") }}
         - odoo
 {{- end }}
-{{- if .Values.applications.open_webui.enabled }}
+{{- if include "app.enabled" (list . "open_webui") }}
         - open-webui
 {{- end }}
-{{- if and .Values.applications.wakapi.enabled (not .Values.applications.wakapi.trusted_header_auth) }}
+{{- if and (include "app.enabled" (list . "wakapi")) (not .Values.applications.wakapi.trusted_header_auth) }}
         - wakapi
 {{- end }}
     additionalObjects:

--- a/charts/services/templates/authentik.yaml
+++ b/charts/services/templates/authentik.yaml
@@ -1,5 +1,5 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.authentik.enabled }}
-{{- if not .Values.applications.postgresql.enabled }}
+{{- if (include "app.enabled" (list . "authentik")) }}
+{{- if not (include "app.enabled" (list . "postgresql")) }}
 {{- fail "Authentik requires PostgreSQL to be enabled. Please enable PostgreSQL in your values.yaml" }}
 {{- end }}
 ---
@@ -129,57 +129,57 @@ spec:
         - authentik-ldap-blueprint
         - authentik-extra-blueprints
         - authentik-traefik-forward-auth
-{{- if .Values.applications.home_assistant.enabled }}
+{{- if (include "app.enabled" (list . "home_assistant")) }}
         - authentik-home-assistant-blueprint
 {{- end }}
-{{- if .Values.applications.immich.enabled }}
+{{- if (include "app.enabled" (list . "immich")) }}
         - immich-authentik-blueprint
 {{- end }}
-{{- if .Values.applications.minio.enabled }}
+{{- if (include "app.enabled" (list . "minio")) }}
         - authentik-minio-blueprint
 {{- end }}
-{{- if .Values.applications.nextcloud.enabled }}
+{{- if (include "app.enabled" (list . "nextcloud")) }}
         - authentik-nextcloud-blueprint
 {{- end }}
-{{- if .Values.applications.odoo.enabled }}
+{{- if (include "app.enabled" (list . "odoo")) }}
         - odoo-authentik-blueprint
 {{- end }}
-{{- if .Values.applications.open_webui.enabled }}
+{{- if (include "app.enabled" (list . "open_webui")) }}
         - authentik-open-webui-blueprint
 {{- end }}
-{{- if .Values.applications.stalwart.enabled }}
+{{- if (include "app.enabled" (list . "stalwart")) }}
         - authentik-stalwart-blueprint
 {{- end }}
-{{- if .Values.applications.vaultwarden.enabled }}
+{{- if (include "app.enabled" (list . "vaultwarden")) }}
         - vaultwarden-authentik-blueprint
 {{- end }}
-{{- if and .Values.applications.wakapi.enabled (not .Values.applications.wakapi.trusted_header_auth) }}
+{{- if and (include "app.enabled" (list . "wakapi")) (not .Values.applications.wakapi.trusted_header_auth) }}
         - wakapi-authentik-blueprint
 {{- end }}
       secrets:
         - ldap
-{{- if .Values.applications.home_assistant.enabled }}
+{{- if (include "app.enabled" (list . "home_assistant")) }}
         - home-assistant-oidc
 {{- end }}
-{{- if .Values.applications.immich.enabled }}
+{{- if (include "app.enabled" (list . "immich")) }}
         - immich
 {{- end }}
-{{- if .Values.applications.minio.enabled }}
+{{- if (include "app.enabled" (list . "minio")) }}
         - minio-oidc
 {{- end }}
-{{- if .Values.applications.nextcloud.enabled }}
+{{- if (include "app.enabled" (list . "nextcloud")) }}
         - nextcloud-oidc
 {{- end }}
-{{- if .Values.applications.odoo.enabled }}
+{{- if (include "app.enabled" (list . "odoo")) }}
         - odoo
 {{- end }}
-{{- if .Values.applications.open_webui.enabled }}
+{{- if (include "app.enabled" (list . "open_webui")) }}
         - open-webui
 {{- end }}
-{{- if .Values.applications.vaultwarden.enabled }}
+{{- if (include "app.enabled" (list . "vaultwarden")) }}
         - vaultwarden
 {{- end }}
-{{- if and .Values.applications.wakapi.enabled (not .Values.applications.wakapi.trusted_header_auth) }}
+{{- if and (include "app.enabled" (list . "wakapi")) (not .Values.applications.wakapi.trusted_header_auth) }}
         - wakapi
 {{- end }}
     additionalObjects:

--- a/charts/services/templates/bazarr.yaml
+++ b/charts/services/templates/bazarr.yaml
@@ -1,5 +1,5 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.bazarr.enabled }}
-{{- if not .Values.applications.postgresql.enabled }}
+{{- if include "app.enabled" (list . "bazarr") }}
+{{- if not (include "app.enabled" (list . "postgresql")) }}
 {{- fail "Bazarr requires PostgreSQL to be enabled. Please enable PostgreSQL in your values.yaml" }}
 {{- end }}
 ---

--- a/charts/services/templates/bazarr.yaml
+++ b/charts/services/templates/bazarr.yaml
@@ -1,5 +1,5 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.bazarr.enabled }}
-{{- if not .Values.applications.postgresql.enabled }}
+{{- if (include "app.enabled" (list . "bazarr")) }}
+{{- if not (include "app.enabled" (list . "postgresql")) }}
 {{- fail "Bazarr requires PostgreSQL to be enabled. Please enable PostgreSQL in your values.yaml" }}
 {{- end }}
 ---

--- a/charts/services/templates/crowdsec.yaml
+++ b/charts/services/templates/crowdsec.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.primaryTenant (not .Values.disableAllApplications) .Values.applications.crowdsec.enabled }}
+{{- if and .Values.primaryTenant (include "app.enabled" (list . "crowdsec")) }}
 # ---
 # apiVersion: v1
 # kind: Secret

--- a/charts/services/templates/ddclient.yaml
+++ b/charts/services/templates/ddclient.yaml
@@ -1,4 +1,4 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.ddclient.enabled }}
+{{- if include "app.enabled" (list . "ddclient") }}
 ---
 apiVersion: helm.cattle.io/v1
 kind: HelmChart

--- a/charts/services/templates/ddclient.yaml
+++ b/charts/services/templates/ddclient.yaml
@@ -1,4 +1,4 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.ddclient.enabled }}
+{{- if (include "app.enabled" (list . "ddclient")) }}
 ---
 apiVersion: helm.cattle.io/v1
 kind: HelmChart

--- a/charts/services/templates/descheduler.yaml
+++ b/charts/services/templates/descheduler.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.primaryTenant (not .Values.disableAllApplications) .Values.applications.descheduler.enabled }}
+{{- if and .Values.primaryTenant (include "app.enabled" (list . "descheduler")) }}
 ---
 apiVersion: helm.cattle.io/v1
 kind: HelmChart
@@ -21,7 +21,7 @@ spec:
         cpu: null
     cmdOptions:
       v: 5
-{{- if and (not .Values.disableAllApplications) .Values.applications.tempo.enabled }}
+{{- if include "app.enabled" (list . "tempo") }}
       # https://github.com/kubernetes-sigs/descheduler/issues/1428
       otel-collector-endpoint: tempo:4317
 {{- end }}

--- a/charts/services/templates/descheduler.yaml
+++ b/charts/services/templates/descheduler.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.primaryTenant (not .Values.disableAllApplications) .Values.applications.descheduler.enabled }}
+{{- if and .Values.primaryTenant (include "app.enabled" (list . "descheduler")) }}
 ---
 apiVersion: helm.cattle.io/v1
 kind: HelmChart
@@ -21,7 +21,7 @@ spec:
         cpu: null
     cmdOptions:
       v: 5
-{{- if and (not .Values.disableAllApplications) .Values.applications.tempo.enabled }}
+{{- if (include "app.enabled" (list . "tempo")) }}
       # https://github.com/kubernetes-sigs/descheduler/issues/1428
       otel-collector-endpoint: tempo:4317
 {{- end }}

--- a/charts/services/templates/epicgames-freegames.yaml
+++ b/charts/services/templates/epicgames-freegames.yaml
@@ -1,5 +1,5 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.epicgames_freegames.enabled }}
-{{- if not .Values.applications.gotify.enabled }}
+{{- if include "app.enabled" (list . "epicgames_freegames") }}
+{{- if not (include "app.enabled" (list . "gotify")) }}
 {{- fail "Epic Games Free Games requires Gotify to be enabled. Please enable Gotify in your values.yaml" }}
 {{- end }}
 ---

--- a/charts/services/templates/epicgames-freegames.yaml
+++ b/charts/services/templates/epicgames-freegames.yaml
@@ -1,5 +1,5 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.epicgames_freegames.enabled }}
-{{- if not .Values.applications.gotify.enabled }}
+{{- if (include "app.enabled" (list . "epicgames_freegames")) }}
+{{- if not (include "app.enabled" (list . "gotify")) }}
 {{- fail "Epic Games Free Games requires Gotify to be enabled. Please enable Gotify in your values.yaml" }}
 {{- end }}
 ---

--- a/charts/services/templates/filebrowser.yaml
+++ b/charts/services/templates/filebrowser.yaml
@@ -1,4 +1,4 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.filebrowser.enabled }}
+{{- if (include "app.enabled" (list . "filebrowser")) }}
 ---
 apiVersion: helm.cattle.io/v1
 kind: HelmChart

--- a/charts/services/templates/filebrowser.yaml
+++ b/charts/services/templates/filebrowser.yaml
@@ -1,4 +1,4 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.filebrowser.enabled }}
+{{- if include "app.enabled" (list . "filebrowser") }}
 ---
 apiVersion: helm.cattle.io/v1
 kind: HelmChart

--- a/charts/services/templates/flaresolverr.yaml
+++ b/charts/services/templates/flaresolverr.yaml
@@ -1,5 +1,5 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.flaresolverr.enabled }}
-{{- if not .Values.applications.gluetun.enabled }}
+{{- if include "app.enabled" (list . "flaresolverr") }}
+{{- if not (include "app.enabled" (list . "gluetun")) }}
 {{- fail "Flaresolverr requires gluetun to be enabled. Please enable gluetun in your values.yaml" }}
 {{- end }}
 ---

--- a/charts/services/templates/flaresolverr.yaml
+++ b/charts/services/templates/flaresolverr.yaml
@@ -1,5 +1,5 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.flaresolverr.enabled }}
-{{- if not .Values.applications.gluetun.enabled }}
+{{- if (include "app.enabled" (list . "flaresolverr")) }}
+{{- if not (include "app.enabled" (list . "gluetun")) }}
 {{- fail "Flaresolverr requires gluetun to be enabled. Please enable gluetun in your values.yaml" }}
 {{- end }}
 ---

--- a/charts/services/templates/gluetun.yaml
+++ b/charts/services/templates/gluetun.yaml
@@ -1,4 +1,4 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.gluetun.enabled }}
+{{- if include "app.enabled" (list . "gluetun") }}
 # ---
 # apiVersion: v1
 # kind: Secret

--- a/charts/services/templates/gluetun.yaml
+++ b/charts/services/templates/gluetun.yaml
@@ -1,4 +1,4 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.gluetun.enabled }}
+{{- if (include "app.enabled" (list . "gluetun")) }}
 # ---
 # apiVersion: v1
 # kind: Secret

--- a/charts/services/templates/gotify.yaml
+++ b/charts/services/templates/gotify.yaml
@@ -1,5 +1,5 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.gotify.enabled }}
-{{- if not .Values.applications.postgresql.enabled }}
+{{- if include "app.enabled" (list . "gotify") }}
+{{- if not (include "app.enabled" (list . "postgresql")) }}
 {{- fail "Gotify requires PostgreSQL to be enabled. Please enable PostgreSQL in your values.yaml" }}
 {{- end }}
 ---

--- a/charts/services/templates/gotify.yaml
+++ b/charts/services/templates/gotify.yaml
@@ -1,5 +1,5 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.gotify.enabled }}
-{{- if not .Values.applications.postgresql.enabled }}
+{{- if (include "app.enabled" (list . "gotify")) }}
+{{- if not (include "app.enabled" (list . "postgresql")) }}
 {{- fail "Gotify requires PostgreSQL to be enabled. Please enable PostgreSQL in your values.yaml" }}
 {{- end }}
 ---

--- a/charts/services/templates/headlamp.yaml
+++ b/charts/services/templates/headlamp.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.primaryTenant (not .Values.disableAllApplications) .Values.applications.headlamp.enabled }}
+{{- if and .Values.primaryTenant (include "app.enabled" (list . "headlamp")) }}
 ---
 apiVersion: helm.cattle.io/v1
 kind: HelmChart

--- a/charts/services/templates/home-assistant.yaml
+++ b/charts/services/templates/home-assistant.yaml
@@ -1,5 +1,5 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.home_assistant.enabled }}
-{{- if not .Values.applications.postgresql.enabled }}
+{{- if include "app.enabled" (list . "home_assistant") }}
+{{- if not (include "app.enabled" (list . "postgresql")) }}
 {{- fail "Home Assistant requires PostgreSQL to be enabled. Please enable PostgreSQL in your values.yaml" }}
 {{- end }}
 ---
@@ -39,7 +39,7 @@ spec:
               echo "" >> "$config"
               cat "$default/http.default" >> "$config"
             fi
-            {{- if .Values.applications.authentik.enabled }}
+            {{- if include "app.enabled" (list . "authentik") }}
             if ! grep -q "openid:" "$config"; then
               echo "Section [openid] does NOT exist in [$config]. Appending..."
               echo "" >> "$config"
@@ -84,7 +84,7 @@ spec:
               purge_keep_days: 30
               commit_interval: 3
               db_url: !env_var DATABASE_URL
-          {{- if .Values.applications.authentik.enabled }}
+          {{- if include "app.enabled" (list . "authentik") }}
           openid.default: |-
             openid:
               client_id: !env_var OIDC_CLIENT_ID
@@ -116,7 +116,7 @@ spec:
                 PGSSLROOTCERT: /etc/postgres/tls/ca.crt
                 PGSSLCERT: /etc/postgres/tls/tls.crt
                 PGSSLKEY: /etc/postgres/tls/tls.key
-                {{- if .Values.applications.authentik.enabled }}
+                {{- if include "app.enabled" (list . "authentik") }}
                 OIDC_CLIENT_ID:
                   secretKeyRef:
                     name: home-assistant-oidc
@@ -251,7 +251,7 @@ spec:
               limits:
                 memory: 1Gi
                 cpu: null
-{{- if .Values.applications.authentik.enabled }}
+{{- if include "app.enabled" (list . "authentik") }}
       - apiVersion: v1
         kind: ConfigMap
         metadata:

--- a/charts/services/templates/home-assistant.yaml
+++ b/charts/services/templates/home-assistant.yaml
@@ -1,5 +1,5 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.home_assistant.enabled }}
-{{- if not .Values.applications.postgresql.enabled }}
+{{- if (include "app.enabled" (list . "home_assistant")) }}
+{{- if not (include "app.enabled" (list . "postgresql")) }}
 {{- fail "Home Assistant requires PostgreSQL to be enabled. Please enable PostgreSQL in your values.yaml" }}
 {{- end }}
 ---
@@ -39,7 +39,7 @@ spec:
               echo "" >> "$config"
               cat "$default/http.default" >> "$config"
             fi
-            {{- if .Values.applications.authentik.enabled }}
+            {{- if (include "app.enabled" (list . "authentik")) }}
             if ! grep -q "openid:" "$config"; then
               echo "Section [openid] does NOT exist in [$config]. Appending..."
               echo "" >> "$config"
@@ -84,7 +84,7 @@ spec:
               purge_keep_days: 30
               commit_interval: 3
               db_url: !env_var DATABASE_URL
-          {{- if .Values.applications.authentik.enabled }}
+          {{- if (include "app.enabled" (list . "authentik")) }}
           openid.default: |-
             openid:
               client_id: !env_var OIDC_CLIENT_ID
@@ -116,7 +116,7 @@ spec:
                 PGSSLROOTCERT: /etc/postgres/tls/ca.crt
                 PGSSLCERT: /etc/postgres/tls/tls.crt
                 PGSSLKEY: /etc/postgres/tls/tls.key
-                {{- if .Values.applications.authentik.enabled }}
+                {{- if (include "app.enabled" (list . "authentik")) }}
                 OIDC_CLIENT_ID:
                   secretKeyRef:
                     name: home-assistant-oidc
@@ -251,7 +251,7 @@ spec:
               limits:
                 memory: 1Gi
                 cpu: null
-{{- if .Values.applications.authentik.enabled }}
+{{- if (include "app.enabled" (list . "authentik")) }}
       - apiVersion: v1
         kind: ConfigMap
         metadata:

--- a/charts/services/templates/homer-operator.yaml
+++ b/charts/services/templates/homer-operator.yaml
@@ -1,4 +1,4 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.homer_operator.enabled }}
+{{- if include "app.enabled" (list . "homer_operator") }}
 ---
 apiVersion: helm.cattle.io/v1
 kind: HelmChart

--- a/charts/services/templates/homer-operator.yaml
+++ b/charts/services/templates/homer-operator.yaml
@@ -1,4 +1,4 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.homer_operator.enabled }}
+{{- if (include "app.enabled" (list . "homer_operator")) }}
 ---
 apiVersion: helm.cattle.io/v1
 kind: HelmChart

--- a/charts/services/templates/idrac-exporter.yaml
+++ b/charts/services/templates/idrac-exporter.yaml
@@ -1,5 +1,5 @@
-{{- if and .Values.primaryTenant (not .Values.disableAllApplications) .Values.applications.idrac_exporter.enabled }}
-{{- if not .Values.applications.prometheus.enabled }}
+{{- if and .Values.primaryTenant (include "app.enabled" (list . "idrac_exporter")) }}
+{{- if not (include "app.enabled" (list . "prometheus")) }}
 {{- fail "iDRAC Exporter requires Prometheus to be enabled. Please enable Prometheus in your values.yaml" }}
 {{- end }}
 

--- a/charts/services/templates/immich.yaml
+++ b/charts/services/templates/immich.yaml
@@ -1,8 +1,8 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.immich.enabled }}
-{{- if not .Values.applications.postgresql.enabled }}
+{{- if include "app.enabled" (list . "immich") }}
+{{- if not (include "app.enabled" (list . "postgresql")) }}
 {{- fail "Immich requires PostgreSQL to be enabled. Please enable PostgreSQL in your values.yaml" }}
 {{- end }}
-{{- if not .Values.applications.redis.enabled }}
+{{- if not (include "app.enabled" (list . "redis")) }}
 {{- fail "Immich requires Redis to be enabled. Please enable Redis in your values.yaml" }}
 {{- end }}
 ---
@@ -46,24 +46,24 @@ spec:
   # default-values: https://github.com/trueforge-org/truecharts/blob/master/charts/stable/immich/values.yaml
   values:
     immich:
-    {{- $mlGpuVendor := dig "machine_learning" "gpu_vendor" "" .Values.applications.immich }}
+    {{- $mlGpuVendor := dig "machine_learning" "gpu_vendor" "" (.Values.applications.immich | default dict) }}
     {{- if eq $mlGpuVendor "intel" }}
-      {{- if not .Values.applications.intel_gpu.enabled }}
+      {{- if not (include "app.enabled" (list . "intel_gpu")) }}
         {{- fail "Intel GPU is selected for Immich but intel_gpu is not enabled" }}
       {{- end }}
       mlImageType: mlOpenvinoImage
     {{- else if eq $mlGpuVendor "intel_xe" }}
-      {{- if not .Values.applications.intel_gpu.enabled }}
+      {{- if not (include "app.enabled" (list . "intel_gpu")) }}
         {{- fail "Intel GPU is selected for Immich's machine learning but intel_gpu is not enabled" }}
       {{- end }}
       mlImageType: mlOpenvinoImage
     {{- else if eq $mlGpuVendor "nvidia" }}
-      {{- if not .Values.applications.nvidia_gpu.enabled }}
+      {{- if not (include "app.enabled" (list . "nvidia_gpu")) }}
         {{- fail "NVIDIA GPU is selected for Immich's machine learning but nvidia_gpu is not enabled" }}
       {{- end }}
       mlImageType: mlCudaImage
     {{- else if eq $mlGpuVendor "amd" }}
-      {{- if not .Values.applications.amd_gpu.enabled }}
+      {{- if not (include "app.enabled" (list . "amd_gpu")) }}
         {{- fail "AMD GPU is selected for Immich's machine learning but amd_gpu is not enabled" }}
       {{- end }}
       mlImageType: mlRocmImage
@@ -132,24 +132,24 @@ spec:
                 limits:
                   cpu: null
                   memory: 4Gi
-                  {{- $gpuVendor := .Values.applications.immich.gpu_vendor }}
+                  {{- $gpuVendor := index (.Values.applications.immich | default dict) "gpu_vendor" }}
                   {{- if eq $gpuVendor "intel" }}
-                    {{- if not .Values.applications.intel_gpu.enabled }}
+                    {{- if not (include "app.enabled" (list . "intel_gpu")) }}
                       {{- fail "Intel GPU is selected for Immich but intel_gpu is not enabled" }}
                     {{- end }}
                   gpu.intel.com/i915: 1
                   {{- else if eq $gpuVendor "intel_xe" }}
-                    {{- if not .Values.applications.intel_gpu.enabled }}
+                    {{- if not (include "app.enabled" (list . "intel_gpu")) }}
                       {{- fail "Intel GPU is selected for Immich but intel_gpu is not enabled" }}
                     {{- end }}
                   gpu.intel.com/xe: 1
                   {{- else if eq $gpuVendor "nvidia" }}
-                    {{- if not .Values.applications.nvidia_gpu.enabled }}
+                    {{- if not (include "app.enabled" (list . "nvidia_gpu")) }}
                       {{- fail "NVIDIA GPU is selected for Immich but nvidia_gpu is not enabled" }}
                     {{- end }}
                   nvidia.com/gpu: 1
                   {{- else if eq $gpuVendor "amd" }}
-                    {{- if not .Values.applications.amd_gpu.enabled }}
+                    {{- if not (include "app.enabled" (list . "amd_gpu")) }}
                       {{- fail "AMD GPU is selected for Immich but amd_gpu is not enabled" }}
                     {{- end }}
                   amd.com/gpu: 1
@@ -293,7 +293,7 @@ spec:
             path: /metrics
     configmap:
       authentik-blueprint:
-        enabled: {{ and .Values.applications.immich.enabled (not .Values.applications.immich.trusted_header_auth) }}
+        enabled: {{ and (include "app.enabled" (list . "immich")) (not .Values.applications.immich.trusted_header_auth) }}
         data:
           blueprint.yaml: |
             # yaml-language-server: $schema=https://goauthentik.io/blueprints/schema.json

--- a/charts/services/templates/immich.yaml
+++ b/charts/services/templates/immich.yaml
@@ -1,8 +1,8 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.immich.enabled }}
-{{- if not .Values.applications.postgresql.enabled }}
+{{- if (include "app.enabled" (list . "immich")) }}
+{{- if not (include "app.enabled" (list . "postgresql")) }}
 {{- fail "Immich requires PostgreSQL to be enabled. Please enable PostgreSQL in your values.yaml" }}
 {{- end }}
-{{- if not .Values.applications.redis.enabled }}
+{{- if not (include "app.enabled" (list . "redis")) }}
 {{- fail "Immich requires Redis to be enabled. Please enable Redis in your values.yaml" }}
 {{- end }}
 ---
@@ -48,22 +48,22 @@ spec:
     immich:
     {{- $mlGpuVendor := dig "machine_learning" "gpu_vendor" "" .Values.applications.immich }}
     {{- if eq $mlGpuVendor "intel" }}
-      {{- if not .Values.applications.intel_gpu.enabled }}
+      {{- if not (include "app.enabled" (list . "intel_gpu")) }}
         {{- fail "Intel GPU is selected for Immich but intel_gpu is not enabled" }}
       {{- end }}
       mlImageType: mlOpenvinoImage
     {{- else if eq $mlGpuVendor "intel_xe" }}
-      {{- if not .Values.applications.intel_gpu.enabled }}
+      {{- if not (include "app.enabled" (list . "intel_gpu")) }}
         {{- fail "Intel GPU is selected for Immich's machine learning but intel_gpu is not enabled" }}
       {{- end }}
       mlImageType: mlOpenvinoImage
     {{- else if eq $mlGpuVendor "nvidia" }}
-      {{- if not .Values.applications.nvidia_gpu.enabled }}
+      {{- if not (include "app.enabled" (list . "nvidia_gpu")) }}
         {{- fail "NVIDIA GPU is selected for Immich's machine learning but nvidia_gpu is not enabled" }}
       {{- end }}
       mlImageType: mlCudaImage
     {{- else if eq $mlGpuVendor "amd" }}
-      {{- if not .Values.applications.amd_gpu.enabled }}
+      {{- if not (include "app.enabled" (list . "amd_gpu")) }}
         {{- fail "AMD GPU is selected for Immich's machine learning but amd_gpu is not enabled" }}
       {{- end }}
       mlImageType: mlRocmImage
@@ -134,22 +134,22 @@ spec:
                   memory: 4Gi
                   {{- $gpuVendor := .Values.applications.immich.gpu_vendor }}
                   {{- if eq $gpuVendor "intel" }}
-                    {{- if not .Values.applications.intel_gpu.enabled }}
+                    {{- if not (include "app.enabled" (list . "intel_gpu")) }}
                       {{- fail "Intel GPU is selected for Immich but intel_gpu is not enabled" }}
                     {{- end }}
                   gpu.intel.com/i915: 1
                   {{- else if eq $gpuVendor "intel_xe" }}
-                    {{- if not .Values.applications.intel_gpu.enabled }}
+                    {{- if not (include "app.enabled" (list . "intel_gpu")) }}
                       {{- fail "Intel GPU is selected for Immich but intel_gpu is not enabled" }}
                     {{- end }}
                   gpu.intel.com/xe: 1
                   {{- else if eq $gpuVendor "nvidia" }}
-                    {{- if not .Values.applications.nvidia_gpu.enabled }}
+                    {{- if not (include "app.enabled" (list . "nvidia_gpu")) }}
                       {{- fail "NVIDIA GPU is selected for Immich but nvidia_gpu is not enabled" }}
                     {{- end }}
                   nvidia.com/gpu: 1
                   {{- else if eq $gpuVendor "amd" }}
-                    {{- if not .Values.applications.amd_gpu.enabled }}
+                    {{- if not (include "app.enabled" (list . "amd_gpu")) }}
                       {{- fail "AMD GPU is selected for Immich but amd_gpu is not enabled" }}
                     {{- end }}
                   amd.com/gpu: 1
@@ -293,7 +293,7 @@ spec:
             path: /metrics
     configmap:
       authentik-blueprint:
-        enabled: {{ and .Values.applications.immich.enabled (not .Values.applications.immich.trusted_header_auth) }}
+        enabled: {{ and (include "app.enabled" (list . "immich")) (not .Values.applications.immich.trusted_header_auth) }}
         data:
           blueprint.yaml: |
             # yaml-language-server: $schema=https://goauthentik.io/blueprints/schema.json

--- a/charts/services/templates/intel-gpu.yaml
+++ b/charts/services/templates/intel-gpu.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.primaryTenant (not .Values.disableAllApplications) .Values.applications.intel_gpu.enabled }}
+{{- if and .Values.primaryTenant (include "app.enabled" (list . "intel_gpu")) }}
 ---
 apiVersion: helm.cattle.io/v1
 kind: HelmChart

--- a/charts/services/templates/inventree.yaml
+++ b/charts/services/templates/inventree.yaml
@@ -1,8 +1,8 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.inventree.enabled }}
-{{- if not .Values.applications.postgresql.enabled }}
+{{- if include "app.enabled" (list . "inventree") }}
+{{- if not (include "app.enabled" (list . "postgresql")) }}
 {{- fail "InvenTree requires PostgreSQL to be enabled. Please enable PostgreSQL in your values.yaml" }}
 {{- end }}
-{{- if not .Values.applications.redis.enabled }}
+{{- if not (include "app.enabled" (list . "redis")) }}
 {{- fail "InvenTree requires Redis to be enabled. Please enable Redis in your values.yaml" }}
 {{- end }}
 ---

--- a/charts/services/templates/inventree.yaml
+++ b/charts/services/templates/inventree.yaml
@@ -1,8 +1,8 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.inventree.enabled }}
-{{- if not .Values.applications.postgresql.enabled }}
+{{- if (include "app.enabled" (list . "inventree")) }}
+{{- if not (include "app.enabled" (list . "postgresql")) }}
 {{- fail "InvenTree requires PostgreSQL to be enabled. Please enable PostgreSQL in your values.yaml" }}
 {{- end }}
-{{- if not .Values.applications.redis.enabled }}
+{{- if not (include "app.enabled" (list . "redis")) }}
 {{- fail "InvenTree requires Redis to be enabled. Please enable Redis in your values.yaml" }}
 {{- end }}
 ---

--- a/charts/services/templates/ipmi-exporter.yaml
+++ b/charts/services/templates/ipmi-exporter.yaml
@@ -1,5 +1,5 @@
-{{- if and .Values.primaryTenant (not .Values.disableAllApplications) .Values.applications.ipmi_exporter.enabled }}
-{{- if not .Values.applications.prometheus.enabled }}
+{{- if and .Values.primaryTenant (include "app.enabled" (list . "ipmi_exporter")) }}
+{{- if not (include "app.enabled" (list . "prometheus")) }}
 {{- fail "IPMI Exporter requires Prometheus to be enabled. Please enable Prometheus in your values.yaml" }}
 {{- end }}
 

--- a/charts/services/templates/jellyfin.yaml
+++ b/charts/services/templates/jellyfin.yaml
@@ -1,4 +1,4 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.jellyfin.enabled }}
+{{- if (include "app.enabled" (list . "jellyfin")) }}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -52,22 +52,22 @@ spec:
         cpu: null
         {{- $gpuVendor := .Values.applications.jellyfin.gpu_vendor }}
         {{- if eq $gpuVendor "intel" }}
-          {{- if not .Values.applications.intel_gpu.enabled }}
+          {{- if not (include "app.enabled" (list . "intel_gpu")) }}
             {{- fail "Intel GPU is selected for Jellyfin but intel_gpu is not enabled" }}
           {{- end }}
         gpu.intel.com/i915: 1
         {{- else if eq $gpuVendor "intel_xe" }}
-          {{- if not .Values.applications.intel_gpu.enabled }}
+          {{- if not (include "app.enabled" (list . "intel_gpu")) }}
             {{- fail "Intel GPU is selected for Jellyfin but intel_gpu is not enabled" }}
           {{- end }}
         gpu.intel.com/xe: 1
         {{- else if eq $gpuVendor "nvidia" }}
-          {{- if not .Values.applications.nvidia_gpu.enabled }}
+          {{- if not (include "app.enabled" (list . "nvidia_gpu")) }}
             {{- fail "NVIDIA GPU is selected for Jellyfin but nvidia_gpu is not enabled" }}
           {{- end }}
         nvidia.com/gpu: 1
         {{- else if eq $gpuVendor "amd" }}
-          {{- if not .Values.applications.amd_gpu.enabled }}
+          {{- if not (include "app.enabled" (list . "amd_gpu")) }}
             {{- fail "AMD GPU is selected for Jellyfin but amd_gpu is not enabled" }}
           {{- end }}
         amd.com/gpu: 1

--- a/charts/services/templates/jellyfin.yaml
+++ b/charts/services/templates/jellyfin.yaml
@@ -1,4 +1,4 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.jellyfin.enabled }}
+{{- if include "app.enabled" (list . "jellyfin") }}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -46,29 +46,25 @@ spec:
       limits:
         memory: 4Gi
         cpu: null
-        {{- $gpuVendor := .Values.applications.jellyfin.gpu_vendor }}
+        {{- $gpuVendor := index (.Values.applications.jellyfin | default dict) "gpu_vendor" }}
         {{- if eq $gpuVendor "intel" }}
-          {{- if not .Values.applications.intel_gpu.enabled }}
+          {{- if not (include "app.enabled" (list . "intel_gpu")) }}
             {{- fail "Intel GPU is selected for Jellyfin but intel_gpu is not enabled" }}
           {{- end }}
         gpu.intel.com/i915: 1
         {{- else if eq $gpuVendor "intel_xe" }}
-          {{- if not .Values.applications.intel_gpu.enabled }}
+          {{- if not (include "app.enabled" (list . "intel_gpu")) }}
             {{- fail "Intel GPU is selected for Jellyfin but intel_gpu is not enabled" }}
           {{- end }}
         gpu.intel.com/xe: 1
         {{- else if eq $gpuVendor "nvidia" }}
-          {{- if not .Values.applications.nvidia_gpu.enabled }}
+          {{- if not (include "app.enabled" (list . "nvidia_gpu")) }}
             {{- fail "NVIDIA GPU is selected for Jellyfin but nvidia_gpu is not enabled" }}
           {{- end }}
         nvidia.com/gpu: 1
         {{- else if eq $gpuVendor "amd" }}
-          {{- if not .Values.applications.amd_gpu.enabled }}
+          {{- if not (include "app.enabled" (list . "amd_gpu")) }}
             {{- fail "AMD GPU is selected for Jellyfin but amd_gpu is not enabled" }}
-          {{- end }}
-        amd.com/gpu: 1
-        {{- else if $gpuVendor }}
-          {{- fail (printf "Unknown GPU vendor '%s' selected for Jellyfin" $gpuVendor) }}
         {{- end }}
     global:
       traefik:

--- a/charts/services/templates/jellyseerr.yaml
+++ b/charts/services/templates/jellyseerr.yaml
@@ -1,4 +1,4 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.jellyseerr.enabled }}
+{{- if include "app.enabled" (list . "jellyseerr") }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/services/templates/jellyseerr.yaml
+++ b/charts/services/templates/jellyseerr.yaml
@@ -1,4 +1,4 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.jellyseerr.enabled }}
+{{- if (include "app.enabled" (list . "jellyseerr")) }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/services/templates/joal.yaml
+++ b/charts/services/templates/joal.yaml
@@ -1,5 +1,5 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.joal.enabled }}
-{{- if not .Values.applications.gluetun.enabled }}
+{{- if include "app.enabled" (list . "joal") }}
+{{- if not (include "app.enabled" (list . "gluetun")) }}
 {{- fail "Joal requires gluetun to be enabled. Please enable gluetun in your values.yaml" }}
 {{- end }}
 # ---

--- a/charts/services/templates/joal.yaml
+++ b/charts/services/templates/joal.yaml
@@ -1,5 +1,5 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.joal.enabled }}
-{{- if not .Values.applications.gluetun.enabled }}
+{{- if (include "app.enabled" (list . "joal")) }}
+{{- if not (include "app.enabled" (list . "gluetun")) }}
 {{- fail "Joal requires gluetun to be enabled. Please enable gluetun in your values.yaml" }}
 {{- end }}
 # ---

--- a/charts/services/templates/lazylibrarian.yaml
+++ b/charts/services/templates/lazylibrarian.yaml
@@ -1,4 +1,4 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.lazylibrarian.enabled }}
+{{- if include "app.enabled" (list . "lazylibrarian") }}
 ---
 apiVersion: helm.cattle.io/v1
 kind: HelmChart

--- a/charts/services/templates/lazylibrarian.yaml
+++ b/charts/services/templates/lazylibrarian.yaml
@@ -1,4 +1,4 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.lazylibrarian.enabled }}
+{{- if (include "app.enabled" (list . "lazylibrarian")) }}
 ---
 apiVersion: helm.cattle.io/v1
 kind: HelmChart

--- a/charts/services/templates/llama.cpp.yaml
+++ b/charts/services/templates/llama.cpp.yaml
@@ -1,4 +1,4 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.llama_cpp.enabled }}
+{{- if include "app.enabled" (list . "llama_cpp") }}
 # ---
 # apiVersion: v1
 # kind: Secret
@@ -51,22 +51,22 @@ spec:
                   cpu: null
                   memory: null
                   {{- if eq $gpuVendor "intel" }}
-                    {{- if not .Values.applications.intel_gpu.enabled }}
+                    {{- if not (include "app.enabled" (list . "intel_gpu")) }}
                       {{- fail "Intel GPU is selected for llama.cpp but intel_gpu is not enabled" }}
                     {{- end }}
                   gpu.intel.com/i915: {{ .Values.applications.llama_cpp.gpu_count }}
                   {{- else if eq $gpuVendor "intel_xe" }}
-                    {{- if not .Values.applications.intel_gpu.enabled }}
+                    {{- if not (include "app.enabled" (list . "intel_gpu")) }}
                       {{- fail "Intel GPU is selected for llama.cpp but intel_gpu is not enabled" }}
                     {{- end }}
                   gpu.intel.com/xe: {{ .Values.applications.llama_cpp.gpu_count }}
                   {{- else if eq $gpuVendor "nvidia" }}
-                    {{- if not .Values.applications.nvidia_gpu.enabled }}
+                    {{- if not (include "app.enabled" (list . "nvidia_gpu")) }}
                       {{- fail "NVIDIA GPU is selected for llama.cpp but nvidia_gpu is not enabled" }}
                     {{- end }}
                   nvidia.com/gpu: {{ .Values.applications.llama_cpp.gpu_count }}
                   {{- else if eq $gpuVendor "amd" }}
-                    {{- if not .Values.applications.amd_gpu.enabled }}
+                    {{- if not (include "app.enabled" (list . "amd_gpu")) }}
                       {{- fail "AMD GPU is selected for llama.cpp but amd_gpu is not enabled" }}
                     {{- end }}
                   amd.com/gpu: {{ .Values.applications.llama_cpp.gpu_count }}

--- a/charts/services/templates/llama.cpp.yaml
+++ b/charts/services/templates/llama.cpp.yaml
@@ -1,4 +1,4 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.llama_cpp.enabled }}
+{{- if (include "app.enabled" (list . "llama_cpp")) }}
 # ---
 # apiVersion: v1
 # kind: Secret
@@ -51,22 +51,22 @@ spec:
                   cpu: null
                   memory: null
                   {{- if eq $gpuVendor "intel" }}
-                    {{- if not .Values.applications.intel_gpu.enabled }}
+                    {{- if not (include "app.enabled" (list . "intel_gpu")) }}
                       {{- fail "Intel GPU is selected for llama.cpp but intel_gpu is not enabled" }}
                     {{- end }}
                   gpu.intel.com/i915: {{ .Values.applications.llama_cpp.gpu_count }}
                   {{- else if eq $gpuVendor "intel_xe" }}
-                    {{- if not .Values.applications.intel_gpu.enabled }}
+                    {{- if not (include "app.enabled" (list . "intel_gpu")) }}
                       {{- fail "Intel GPU is selected for llama.cpp but intel_gpu is not enabled" }}
                     {{- end }}
                   gpu.intel.com/xe: {{ .Values.applications.llama_cpp.gpu_count }}
                   {{- else if eq $gpuVendor "nvidia" }}
-                    {{- if not .Values.applications.nvidia_gpu.enabled }}
+                    {{- if not (include "app.enabled" (list . "nvidia_gpu")) }}
                       {{- fail "NVIDIA GPU is selected for llama.cpp but nvidia_gpu is not enabled" }}
                     {{- end }}
                   nvidia.com/gpu: {{ .Values.applications.llama_cpp.gpu_count }}
                   {{- else if eq $gpuVendor "amd" }}
-                    {{- if not .Values.applications.amd_gpu.enabled }}
+                    {{- if not (include "app.enabled" (list . "amd_gpu")) }}
                       {{- fail "AMD GPU is selected for llama.cpp but amd_gpu is not enabled" }}
                     {{- end }}
                   amd.com/gpu: {{ .Values.applications.llama_cpp.gpu_count }}

--- a/charts/services/templates/loki.yaml
+++ b/charts/services/templates/loki.yaml
@@ -1,8 +1,8 @@
-{{- if and .Values.primaryTenant (not .Values.disableAllApplications) .Values.applications.loki.enabled }}
-{{- if not .Values.applications.prometheus.enabled }}
+{{- if and .Values.primaryTenant (include "app.enabled" (list . "loki")) }}
+{{- if not (include "app.enabled" (list . "prometheus")) }}
 {{- fail "Loki requires Prometheus to be enabled. Please enable Prometheus in your values.yaml" }}
 {{- end }}
-{{- if not .Values.applications.minio.enabled }}
+{{- if not (include "app.enabled" (list . "minio")) }}
 {{- fail "Loki requires MinIO to be enabled. Please enable MinIO in your values.yaml" }}
 {{- end }}
 # ---

--- a/charts/services/templates/minecraft-bedrock.yaml
+++ b/charts/services/templates/minecraft-bedrock.yaml
@@ -1,4 +1,4 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.minecraft_bedrock.enabled }}
+{{- if include "app.enabled" (list . "minecraft_bedrock") }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/services/templates/minecraft-bedrock.yaml
+++ b/charts/services/templates/minecraft-bedrock.yaml
@@ -1,4 +1,4 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.minecraft_bedrock.enabled }}
+{{- if (include "app.enabled" (list . "minecraft_bedrock")) }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/services/templates/miniflux.yaml
+++ b/charts/services/templates/miniflux.yaml
@@ -1,5 +1,5 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.miniflux.enabled }}
-{{- if not .Values.applications.postgresql.enabled }}
+{{- if include "app.enabled" (list . "miniflux") }}
+{{- if not (include "app.enabled" (list . "postgresql")) }}
 {{- fail "Miniflux requires PostgreSQL to be enabled. Please enable PostgreSQL in your values.yaml" }}
 {{- end }}
 # ---

--- a/charts/services/templates/miniflux.yaml
+++ b/charts/services/templates/miniflux.yaml
@@ -1,5 +1,5 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.miniflux.enabled }}
-{{- if not .Values.applications.postgresql.enabled }}
+{{- if (include "app.enabled" (list . "miniflux")) }}
+{{- if not (include "app.enabled" (list . "postgresql")) }}
 {{- fail "Miniflux requires PostgreSQL to be enabled. Please enable PostgreSQL in your values.yaml" }}
 {{- end }}
 # ---

--- a/charts/services/templates/minio.yaml
+++ b/charts/services/templates/minio.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.primaryTenant (not .Values.disableAllApplications) .Values.applications.minio.enabled }}
+{{- if and .Values.primaryTenant (include "app.enabled" (list . "minio")) }}
 ---
 apiVersion: helm.cattle.io/v1
 kind: HelmChart
@@ -25,7 +25,7 @@ spec:
           memory: 512Mi
 {{- end }}
 
-{{- if and (not .Values.disableAllApplications) .Values.applications.minio.enabled }}
+{{- if include "app.enabled" (list . "minio") }}
 # ---
 # apiVersion: v1
 # kind: Secret
@@ -85,24 +85,24 @@ spec:
       metrics:
         enabled: {{ include "metrics.enabled" . }}
       prometheusOperator: {{ include "metrics.enabled" . }}
-{{- if or (and .Values.primaryTenant (or .Values.applications.loki.enabled .Values.applications.tempo.enabled)) .Values.applications.stalwart.enabled }}
+{{- if or (and .Values.primaryTenant (or (include "app.enabled" (list . "loki")) (include "app.enabled" (list . "tempo")))) (include "app.enabled" (list . "stalwart")) }}
       buckets:
-{{- if and .Values.primaryTenant .Values.applications.loki.enabled }}
+{{- if and .Values.primaryTenant (include "app.enabled" (list . "loki")) }}
         - name: loki-admin
         - name: loki-chunks
         - name: loki-ruler
 {{- end }}
-{{- if and .Values.primaryTenant .Values.applications.tempo.enabled }}
+{{- if and .Values.primaryTenant (include "app.enabled" (list . "tempo")) }}
         - name: tempo
 {{- end }}
-{{- if .Values.applications.stalwart.enabled }}
+{{- if include "app.enabled" (list . "stalwart") }}
         - name: stalwart
 {{- end }}
 {{- end }}
       env:
         - name: MINIO_BROWSER_REDIRECT_URL
           value: "https://minio.{{ .Values.fqdn }}"
-{{- if .Values.applications.authentik.enabled }}
+{{- if include "app.enabled" (list . "authentik") }}
         - name: MINIO_IDENTITY_OPENID_CONFIG_URL
           value: "https://auth.{{ .Values.fqdn }}/application/o/minio/.well-known/openid-configuration"
         - name: MINIO_IDENTITY_OPENID_CLIENT_ID
@@ -147,7 +147,7 @@ spec:
         host: minio.{{ .Values.fqdn }}
         path: /
         pathType: Prefix
-{{- if .Values.applications.authentik.enabled }}
+{{- if include "app.enabled" (list . "authentik") }}
     extraResources:
       - apiVersion: v1
         kind: ConfigMap

--- a/charts/services/templates/minio.yaml
+++ b/charts/services/templates/minio.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.primaryTenant (not .Values.disableAllApplications) .Values.applications.minio.enabled }}
+{{- if and .Values.primaryTenant (include "app.enabled" (list . "minio")) }}
 ---
 apiVersion: helm.cattle.io/v1
 kind: HelmChart
@@ -25,7 +25,7 @@ spec:
           memory: 512Mi
 {{- end }}
 
-{{- if and (not .Values.disableAllApplications) .Values.applications.minio.enabled }}
+{{- if (include "app.enabled" (list . "minio")) }}
 # ---
 # apiVersion: v1
 # kind: Secret
@@ -85,24 +85,24 @@ spec:
       metrics:
         enabled: {{ include "metrics.enabled" . }}
       prometheusOperator: {{ include "metrics.enabled" . }}
-{{- if or (and .Values.primaryTenant (or .Values.applications.loki.enabled .Values.applications.tempo.enabled)) .Values.applications.stalwart.enabled }}
+{{- if or (and .Values.primaryTenant (or (include "app.enabled" (list . "loki")) (include "app.enabled" (list . "tempo")))) (include "app.enabled" (list . "stalwart")) }}
       buckets:
-{{- if and .Values.primaryTenant .Values.applications.loki.enabled }}
+{{- if and .Values.primaryTenant (include "app.enabled" (list . "loki")) }}
         - name: loki-admin
         - name: loki-chunks
         - name: loki-ruler
 {{- end }}
-{{- if and .Values.primaryTenant .Values.applications.tempo.enabled }}
+{{- if and .Values.primaryTenant (include "app.enabled" (list . "tempo")) }}
         - name: tempo
 {{- end }}
-{{- if .Values.applications.stalwart.enabled }}
+{{- if (include "app.enabled" (list . "stalwart")) }}
         - name: stalwart
 {{- end }}
 {{- end }}
       env:
         - name: MINIO_BROWSER_REDIRECT_URL
           value: "https://minio.{{ .Values.fqdn }}"
-{{- if .Values.applications.authentik.enabled }}
+{{- if (include "app.enabled" (list . "authentik")) }}
         - name: MINIO_IDENTITY_OPENID_CONFIG_URL
           value: "https://auth.{{ .Values.fqdn }}/application/o/minio/.well-known/openid-configuration"
         - name: MINIO_IDENTITY_OPENID_CLIENT_ID
@@ -147,7 +147,7 @@ spec:
         host: minio.{{ .Values.fqdn }}
         path: /
         pathType: Prefix
-{{- if .Values.applications.authentik.enabled }}
+{{- if (include "app.enabled" (list . "authentik")) }}
     extraResources:
       - apiVersion: v1
         kind: ConfigMap

--- a/charts/services/templates/mosquitto.yaml
+++ b/charts/services/templates/mosquitto.yaml
@@ -1,4 +1,4 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.mosquitto.enabled }}
+{{- if include "app.enabled" (list . "mosquitto") }}
 ---
 apiVersion: helm.cattle.io/v1
 kind: HelmChart

--- a/charts/services/templates/mosquitto.yaml
+++ b/charts/services/templates/mosquitto.yaml
@@ -1,4 +1,4 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.mosquitto.enabled }}
+{{- if (include "app.enabled" (list . "mosquitto")) }}
 ---
 apiVersion: helm.cattle.io/v1
 kind: HelmChart

--- a/charts/services/templates/n8n.yaml
+++ b/charts/services/templates/n8n.yaml
@@ -1,8 +1,8 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.n8n.enabled }}
-{{- if not .Values.applications.postgresql.enabled }}
+{{- if include "app.enabled" (list . "n8n") }}
+{{- if not (include "app.enabled" (list . "postgresql")) }}
 {{- fail "n8n requires PostgreSQL to be enabled. Please enable PostgreSQL in your values.yaml" }}
 {{- end }}
-{{- if not .Values.applications.redis.enabled }}
+{{- if not (include "app.enabled" (list . "redis")) }}
 {{- fail "n8n requires Redis to be enabled. Please enable Redis in your values.yaml" }}
 {{- end }}
 # ---

--- a/charts/services/templates/n8n.yaml
+++ b/charts/services/templates/n8n.yaml
@@ -1,8 +1,8 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.n8n.enabled }}
-{{- if not .Values.applications.postgresql.enabled }}
+{{- if (include "app.enabled" (list . "n8n")) }}
+{{- if not (include "app.enabled" (list . "postgresql")) }}
 {{- fail "n8n requires PostgreSQL to be enabled. Please enable PostgreSQL in your values.yaml" }}
 {{- end }}
-{{- if not .Values.applications.redis.enabled }}
+{{- if not (include "app.enabled" (list . "redis")) }}
 {{- fail "n8n requires Redis to be enabled. Please enable Redis in your values.yaml" }}
 {{- end }}
 # ---

--- a/charts/services/templates/netbox.yaml
+++ b/charts/services/templates/netbox.yaml
@@ -1,8 +1,8 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.netbox.enabled }}
-{{- if not .Values.applications.postgresql.enabled }}
+{{- if include "app.enabled" (list . "netbox") }}
+{{- if not (include "app.enabled" (list . "postgresql")) }}
 {{- fail "netbox requires PostgreSQL to be enabled. Please enable PostgreSQL in your values.yaml" }}
 {{- end }}
-{{- if not .Values.applications.redis.enabled }}
+{{- if not (include "app.enabled" (list . "redis")) }}
 {{- fail "netbox requires Redis to be enabled. Please enable Redis in your values.yaml" }}
 {{- end }}
 

--- a/charts/services/templates/netbox.yaml
+++ b/charts/services/templates/netbox.yaml
@@ -1,8 +1,8 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.netbox.enabled }}
-{{- if not .Values.applications.postgresql.enabled }}
+{{- if (include "app.enabled" (list . "netbox")) }}
+{{- if not (include "app.enabled" (list . "postgresql")) }}
 {{- fail "netbox requires PostgreSQL to be enabled. Please enable PostgreSQL in your values.yaml" }}
 {{- end }}
-{{- if not .Values.applications.redis.enabled }}
+{{- if not (include "app.enabled" (list . "redis")) }}
 {{- fail "netbox requires Redis to be enabled. Please enable Redis in your values.yaml" }}
 {{- end }}
 

--- a/charts/services/templates/nextcloud.yaml
+++ b/charts/services/templates/nextcloud.yaml
@@ -1,8 +1,8 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.nextcloud.enabled }}
-{{- if not .Values.applications.postgresql.enabled }}
+{{- if include "app.enabled" (list . "nextcloud") }}
+{{- if not (include "app.enabled" (list . "postgresql")) }}
 {{- fail "Nextcloud requires PostgreSQL to be enabled. Please enable PostgreSQL in your values.yaml" }}
 {{- end }}
-{{- if not .Values.applications.redis.enabled }}
+{{- if not (include "app.enabled" (list . "redis")) }}
 {{- fail "Nextcloud requires Redis to be enabled. Please enable Redis in your values.yaml" }}
 {{- end }}
 ---
@@ -192,7 +192,7 @@ spec:
         - secretName: {{ .Values.fqdn }}-tls
           hosts:
             - nextcloud.{{ .Values.fqdn }}
-{{- if .Values.applications.authentik.enabled }}
+{{- if include "app.enabled" (list . "authentik") }}
     extraManifests:
       - apiVersion: v1
         kind: ConfigMap

--- a/charts/services/templates/nextcloud.yaml
+++ b/charts/services/templates/nextcloud.yaml
@@ -1,8 +1,8 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.nextcloud.enabled }}
-{{- if not .Values.applications.postgresql.enabled }}
+{{- if (include "app.enabled" (list . "nextcloud")) }}
+{{- if not (include "app.enabled" (list . "postgresql")) }}
 {{- fail "Nextcloud requires PostgreSQL to be enabled. Please enable PostgreSQL in your values.yaml" }}
 {{- end }}
-{{- if not .Values.applications.redis.enabled }}
+{{- if not (include "app.enabled" (list . "redis")) }}
 {{- fail "Nextcloud requires Redis to be enabled. Please enable Redis in your values.yaml" }}
 {{- end }}
 ---
@@ -192,7 +192,7 @@ spec:
         - secretName: {{ .Values.fqdn }}-tls
           hosts:
             - nextcloud.{{ .Values.fqdn }}
-{{- if .Values.applications.authentik.enabled }}
+{{- if (include "app.enabled" (list . "authentik")) }}
     extraManifests:
       - apiVersion: v1
         kind: ConfigMap

--- a/charts/services/templates/node-problem-detector.yaml
+++ b/charts/services/templates/node-problem-detector.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.primaryTenant (not .Values.disableAllApplications) .Values.applications.node_problem_detector.enabled }}
+{{- if and .Values.primaryTenant (include "app.enabled" (list . "node_problem_detector")) }}
 ---
 apiVersion: helm.cattle.io/v1
 kind: HelmChart

--- a/charts/services/templates/nvidia-gpu.yaml
+++ b/charts/services/templates/nvidia-gpu.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.primaryTenant (not .Values.disableAllApplications) .Values.applications.nvidia_gpu.enabled }}
+{{- if and .Values.primaryTenant (include "app.enabled" (list . "nvidia_gpu")) }}
 ---
 apiVersion: helm.cattle.io/v1
 kind: HelmChart

--- a/charts/services/templates/obico.yaml
+++ b/charts/services/templates/obico.yaml
@@ -1,11 +1,11 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.obico.enabled }}
-{{- if not .Values.applications.postgresql.enabled }}
+{{- if include "app.enabled" (list . "obico") }}
+{{- if not (include "app.enabled" (list . "postgresql")) }}
 {{- fail "Obico requires PostgreSQL to be enabled. Please enable PostgreSQL in your values.yaml" }}
 {{- end }}
-{{- if not .Values.applications.redis.enabled }}
+{{- if not (include "app.enabled" (list . "redis")) }}
 {{- fail "Obico requires Redis to be enabled. Please enable Redis in your values.yaml" }}
 {{- end }}
-{{- if not .Values.applications.octoprint.enabled }}
+{{- if not (include "app.enabled" (list . "octoprint")) }}
 {{- fail "Obico requires OctoPrint to be enabled. Please enable OctoPrint in your values.yaml" }}
 {{- end }}
 # ---

--- a/charts/services/templates/obico.yaml
+++ b/charts/services/templates/obico.yaml
@@ -1,11 +1,11 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.obico.enabled }}
-{{- if not .Values.applications.postgresql.enabled }}
+{{- if (include "app.enabled" (list . "obico")) }}
+{{- if not (include "app.enabled" (list . "postgresql")) }}
 {{- fail "Obico requires PostgreSQL to be enabled. Please enable PostgreSQL in your values.yaml" }}
 {{- end }}
-{{- if not .Values.applications.redis.enabled }}
+{{- if not (include "app.enabled" (list . "redis")) }}
 {{- fail "Obico requires Redis to be enabled. Please enable Redis in your values.yaml" }}
 {{- end }}
-{{- if not .Values.applications.octoprint.enabled }}
+{{- if not (include "app.enabled" (list . "octoprint")) }}
 {{- fail "Obico requires OctoPrint to be enabled. Please enable OctoPrint in your values.yaml" }}
 {{- end }}
 # ---

--- a/charts/services/templates/octoprint.yaml
+++ b/charts/services/templates/octoprint.yaml
@@ -1,4 +1,4 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.octoprint.enabled }}
+{{- if include "app.enabled" (list . "octoprint") }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/services/templates/octoprint.yaml
+++ b/charts/services/templates/octoprint.yaml
@@ -1,4 +1,4 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.octoprint.enabled }}
+{{- if (include "app.enabled" (list . "octoprint")) }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/services/templates/odoo.yaml
+++ b/charts/services/templates/odoo.yaml
@@ -1,5 +1,5 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.odoo.enabled }}
-{{- if not .Values.applications.postgresql.enabled }}
+{{- if include "app.enabled" (list . "odoo") }}
+{{- if not (include "app.enabled" (list . "postgresql")) }}
 {{- fail "Odoo requires PostgreSQL to be enabled. Please enable PostgreSQL in your values.yaml" }}
 {{- end }}
 ---
@@ -80,7 +80,7 @@ spec:
             admin_passwd = admin
             list_db = False
       authentik-blueprint:
-        enabled: {{ .Values.applications.authentik.enabled }}
+        enabled: {{ include "app.enabled" (list . "authentik") }}
         data:
           blueprint.yaml: |
             # yaml-language-server: $schema=https://goauthentik.io/blueprints/schema.json
@@ -159,7 +159,7 @@ spec:
         creds:
           host: "dummy"
           password: "dummy"
-{{- if .Values.applications.authentik.enabled }}
+{{- if include "app.enabled" (list . "authentik") }}
     extraTpl:
       - apiVersion: external-secrets.io/v1
         kind: ExternalSecret

--- a/charts/services/templates/odoo.yaml
+++ b/charts/services/templates/odoo.yaml
@@ -1,5 +1,5 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.odoo.enabled }}
-{{- if not .Values.applications.postgresql.enabled }}
+{{- if (include "app.enabled" (list . "odoo")) }}
+{{- if not (include "app.enabled" (list . "postgresql")) }}
 {{- fail "Odoo requires PostgreSQL to be enabled. Please enable PostgreSQL in your values.yaml" }}
 {{- end }}
 ---
@@ -86,7 +86,7 @@ spec:
             admin_passwd = admin
             list_db = False
       authentik-blueprint:
-        enabled: {{ .Values.applications.authentik.enabled }}
+        enabled: {{ (include "app.enabled" (list . "authentik")) }}
         data:
           blueprint.yaml: |
             # yaml-language-server: $schema=https://goauthentik.io/blueprints/schema.json
@@ -185,7 +185,7 @@ spec:
         creds:
           host: "dummy"
           password: "dummy"
-{{- if .Values.applications.authentik.enabled }}
+{{- if (include "app.enabled" (list . "authentik")) }}
     extraTpl:
       - apiVersion: external-secrets.io/v1
         kind: ExternalSecret

--- a/charts/services/templates/open-webui.yaml
+++ b/charts/services/templates/open-webui.yaml
@@ -1,5 +1,5 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.open_webui.enabled }}
-{{- if not .Values.applications.postgresql.enabled }}
+{{- if include "app.enabled" (list . "open_webui") }}
+{{- if not (include "app.enabled" (list . "postgresql")) }}
 {{- fail "Open WebUI requires PostgreSQL to be enabled. Please enable PostgreSQL in your values.yaml" }}
 {{- end }}
 
@@ -22,7 +22,7 @@ spec:
       enabled: false
     postgresql:
       enabled: false
-{{- if .Values.applications.llama_cpp.enabled }}
+{{- if include "app.enabled" (list . "llama_cpp") }}
     openaiBaseApiUrl: "http://llama-cpp:8080/v1"
     openaiBaseApiUrls:
       - "http://llama-cpp:8080/v1"
@@ -63,7 +63,7 @@ spec:
           secretKeyRef:
             name: hugging-face
             key: token
-    {{- if .Values.applications.authentik.enabled }}
+    {{- if include "app.enabled" (list . "authentik") }}
     sso:
       enabled: true
       enableSignup: true
@@ -92,7 +92,7 @@ spec:
       host: chat.{{ .Values.fqdn }}
       tls: true
       existingSecret: "{{ .Values.fqdn }}-tls"
-    {{- if .Values.applications.authentik.enabled }}
+    {{- if include "app.enabled" (list . "authentik") }}
     extraResources:
       - apiVersion: v1
         kind: ConfigMap

--- a/charts/services/templates/open-webui.yaml
+++ b/charts/services/templates/open-webui.yaml
@@ -1,5 +1,5 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.open_webui.enabled }}
-{{- if not .Values.applications.postgresql.enabled }}
+{{- if (include "app.enabled" (list . "open_webui")) }}
+{{- if not (include "app.enabled" (list . "postgresql")) }}
 {{- fail "Open WebUI requires PostgreSQL to be enabled. Please enable PostgreSQL in your values.yaml" }}
 {{- end }}
 
@@ -22,7 +22,7 @@ spec:
       enabled: false
     postgresql:
       enabled: false
-{{- if .Values.applications.llama_cpp.enabled }}
+{{- if (include "app.enabled" (list . "llama_cpp")) }}
     openaiBaseApiUrl: "http://llama-cpp:8080/v1"
     openaiBaseApiUrls:
       - "http://llama-cpp:8080/v1"
@@ -63,7 +63,7 @@ spec:
           secretKeyRef:
             name: hugging-face
             key: token
-    {{- if .Values.applications.authentik.enabled }}
+    {{- if (include "app.enabled" (list . "authentik")) }}
     sso:
       enabled: true
       enableSignup: true
@@ -92,7 +92,7 @@ spec:
       host: chat.{{ .Values.fqdn }}
       tls: true
       existingSecret: "{{ .Values.fqdn }}-tls"
-    {{- if .Values.applications.authentik.enabled }}
+    {{- if (include "app.enabled" (list . "authentik")) }}
     extraResources:
       - apiVersion: v1
         kind: ConfigMap

--- a/charts/services/templates/pgadmin4.yaml
+++ b/charts/services/templates/pgadmin4.yaml
@@ -1,5 +1,5 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.pgadmin4.enabled }}
-{{- if not .Values.applications.postgresql.enabled }}
+{{- if include "app.enabled" (list . "pgadmin4") }}
+{{- if not (include "app.enabled" (list . "postgresql")) }}
 {{- fail "pgAdmin4 requires PostgreSQL to be enabled. Please enable PostgreSQL in your values.yaml" }}
 {{- end }}
 # ---

--- a/charts/services/templates/pgadmin4.yaml
+++ b/charts/services/templates/pgadmin4.yaml
@@ -1,5 +1,5 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.pgadmin4.enabled }}
-{{- if not .Values.applications.postgresql.enabled }}
+{{- if (include "app.enabled" (list . "pgadmin4")) }}
+{{- if not (include "app.enabled" (list . "postgresql")) }}
 {{- fail "pgAdmin4 requires PostgreSQL to be enabled. Please enable PostgreSQL in your values.yaml" }}
 {{- end }}
 # ---

--- a/charts/services/templates/postgresql.yaml
+++ b/charts/services/templates/postgresql.yaml
@@ -1,4 +1,4 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.postgresql.enabled }}
+{{- if include "app.enabled" (list . "postgresql") }}
 {{- if .Values.primaryTenant }}
 ---
 apiVersion: helm.cattle.io/v1
@@ -409,7 +409,7 @@ spec:
             FROM dbs;
             \o
             \i /tmp/grant_users_public_permissions.sql
-{{- if .Values.applications.immich.enabled }}
+{{- if include "app.enabled" (list . "immich") }}
             \c immich
             BEGIN;
             CREATE EXTENSION IF NOT EXISTS earthdistance CASCADE;
@@ -417,13 +417,13 @@ spec:
             CREATE EXTENSION IF NOT EXISTS vchord CASCADE;
             COMMIT;
 {{- end }}
-{{- if .Values.applications.odoo.enabled }}
+{{- if include "app.enabled" (list . "odoo") }}
             \c odoo
             BEGIN;
             CREATE EXTENSION IF NOT EXISTS vector CASCADE;
             COMMIT;
 {{- end }}
-{{- if .Values.applications.tracearr.enabled }}
+{{- if include "app.enabled" (list . "tracearr") }}
             \c tracearr
             BEGIN;
             CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE;
@@ -475,124 +475,124 @@ spec:
                   - "hostssl all all 10.42.0.0/16 scram-sha-256"
                   - "hostssl all all 10.43.0.0/16 scram-sha-256"
                   # Remove once https://github.com/stalwartlabs/stalwart/issues/2380 is resolved and the application no longer requires non-SSL connections to the database
-{{- if .Values.applications.stalwart.enabled }}
+{{- if include "app.enabled" (list . "stalwart") }}
                   - "hostnossl stalwart stalwart 10.42.0.0/16 scram-sha-256"
                   - "hostnossl stalwart stalwart 10.43.0.0/16 scram-sha-256"
 {{- end }}
           users:
             - name: postgres
-{{- if .Values.applications.authentik.enabled }}
+{{- if include "app.enabled" (list . "authentik") }}
             - name: authentik
               databases:
                 - authentik
 {{- end }}
-{{- if .Values.applications.bazarr.enabled }}
+{{- if include "app.enabled" (list . "bazarr") }}
             - name: bazarr
               databases:
                 - bazarr
 {{- end }}
-{{- if .Values.applications.gotify.enabled }}
+{{- if include "app.enabled" (list . "gotify") }}
             - name: gotify
               databases:
                 - gotify
 {{- end }}
-{{- if .Values.applications.home_assistant.enabled }}
+{{- if include "app.enabled" (list . "home_assistant") }}
             - name: home-assistant
               databases:
                 - home-assistant
 {{- end }}
-{{- if .Values.applications.immich.enabled }}
+{{- if include "app.enabled" (list . "immich") }}
             - name: immich
               databases:
                 - immich
 {{- end }}
-{{- if .Values.applications.inventree.enabled }}
+{{- if include "app.enabled" (list . "inventree") }}
             - name: inventree
               databases:
                 - inventree
 {{- end }}
-{{- if .Values.applications.miniflux.enabled }}
+{{- if include "app.enabled" (list . "miniflux") }}
             - name: miniflux
               password:
                 type: AlphaNumeric
               databases:
                 - miniflux
 {{- end }}
-{{- if .Values.applications.n8n.enabled }}
+{{- if include "app.enabled" (list . "n8n") }}
             - name: n8n
               databases:
                 - n8n
 {{- end }}
-{{- if .Values.applications.netbox.enabled }}
+{{- if include "app.enabled" (list . "netbox") }}
             - name: netbox
               databases:
                 - netbox
 {{- end }}
-{{- if .Values.applications.nextcloud.enabled }}
+{{- if include "app.enabled" (list . "nextcloud") }}
             - name: nextcloud
               databases:
                 - nextcloud
 {{- end }}
-{{- if .Values.applications.obico.enabled }}
+{{- if include "app.enabled" (list . "obico") }}
             - name: obico
               password:
                 type: AlphaNumeric
               databases:
                 - obico
 {{- end }}
-{{- if .Values.applications.odoo.enabled }}
+{{- if include "app.enabled" (list . "odoo") }}
             - name: odoo
               databases:
                 - odoo
 {{- end }}
-{{- if .Values.applications.open_webui.enabled }}
+{{- if include "app.enabled" (list . "open_webui") }}
             - name: open-webui
               databases:
                 - open-webui
 {{- end }}
-{{- if .Values.applications.pgadmin4.enabled }}
+{{- if include "app.enabled" (list . "pgadmin4") }}
             - name: pgadmin4
               password:
                 type: AlphaNumeric
               databases:
                 - pgadmin4
 {{- end }}
-{{- if .Values.applications.prowlarr.enabled }}
+{{- if include "app.enabled" (list . "prowlarr") }}
             - name: prowlarr
               databases:
                 - prowlarr_log
                 - prowlarr_main
 {{- end }}
-{{- if .Values.applications.radarr.enabled }}
+{{- if include "app.enabled" (list . "radarr") }}
             - name: radarr
               databases:
                 - radarr_log
                 - radarr_main
 {{- end }}
-{{- if .Values.applications.sonarr.enabled }}
+{{- if include "app.enabled" (list . "sonarr") }}
             - name: sonarr
               databases:
                 - sonarr_log
                 - sonarr_main
 {{- end }}
-{{- if .Values.applications.speedtest_tracker.enabled }}
+{{- if include "app.enabled" (list . "speedtest_tracker") }}
             - name: speedtest-tracker
               databases:
                 - speedtest-tracker
 {{- end }}
-{{- if .Values.applications.stalwart.enabled }}
+{{- if include "app.enabled" (list . "stalwart") }}
             - name: stalwart
               databases:
                 - stalwart
 {{- end }}
-{{- if .Values.applications.tracearr.enabled }}
+{{- if include "app.enabled" (list . "tracearr") }}
             - name: tracearr
               password:
                 type: AlphaNumeric
               databases:
                 - tracearr
 {{- end }}
-{{- if .Values.applications.wakapi.enabled }}
+{{- if include "app.enabled" (list . "wakapi") }}
             - name: wakapi
               databases:
                 - wakapi

--- a/charts/services/templates/postgresql.yaml
+++ b/charts/services/templates/postgresql.yaml
@@ -1,4 +1,4 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.postgresql.enabled }}
+{{- if (include "app.enabled" (list . "postgresql")) }}
 {{- if .Values.primaryTenant }}
 ---
 apiVersion: helm.cattle.io/v1
@@ -409,7 +409,7 @@ spec:
             FROM dbs;
             \o
             \i /tmp/grant_users_public_permissions.sql
-{{- if .Values.applications.immich.enabled }}
+{{- if (include "app.enabled" (list . "immich")) }}
             \c immich
             BEGIN;
             CREATE EXTENSION IF NOT EXISTS earthdistance CASCADE;
@@ -417,13 +417,13 @@ spec:
             CREATE EXTENSION IF NOT EXISTS vchord CASCADE;
             COMMIT;
 {{- end }}
-{{- if .Values.applications.odoo.enabled }}
+{{- if (include "app.enabled" (list . "odoo")) }}
             \c odoo
             BEGIN;
             CREATE EXTENSION IF NOT EXISTS vector CASCADE;
             COMMIT;
 {{- end }}
-{{- if .Values.applications.tracearr.enabled }}
+{{- if (include "app.enabled" (list . "tracearr")) }}
             \c tracearr
             BEGIN;
             CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE;
@@ -475,131 +475,131 @@ spec:
                   - "hostssl all all 10.42.0.0/16 scram-sha-256"
                   - "hostssl all all 10.43.0.0/16 scram-sha-256"
                   # Remove once https://github.com/stalwartlabs/stalwart/issues/2380 is resolved and the application no longer requires non-SSL connections to the database
-{{- if .Values.applications.stalwart.enabled }}
+{{- if (include "app.enabled" (list . "stalwart")) }}
                   - "hostnossl stalwart stalwart 10.42.0.0/16 scram-sha-256"
                   - "hostnossl stalwart stalwart 10.43.0.0/16 scram-sha-256"
 {{- end }}
           users:
             - name: postgres
-{{- if .Values.applications.authentik.enabled }}
+{{- if (include "app.enabled" (list . "authentik")) }}
             - name: authentik
               databases:
                 - authentik
 {{- end }}
-{{- if .Values.applications.bazarr.enabled }}
+{{- if (include "app.enabled" (list . "bazarr")) }}
             - name: bazarr
               databases:
                 - bazarr
 {{- end }}
-{{- if .Values.applications.gotify.enabled }}
+{{- if (include "app.enabled" (list . "gotify")) }}
             - name: gotify
               databases:
                 - gotify
 {{- end }}
-{{- if .Values.applications.home_assistant.enabled }}
+{{- if (include "app.enabled" (list . "home_assistant")) }}
             - name: home-assistant
               databases:
                 - home-assistant
 {{- end }}
-{{- if .Values.applications.immich.enabled }}
+{{- if (include "app.enabled" (list . "immich")) }}
             - name: immich
               databases:
                 - immich
 {{- end }}
-{{- if .Values.applications.inventree.enabled }}
+{{- if (include "app.enabled" (list . "inventree")) }}
             - name: inventree
               databases:
                 - inventree
 {{- end }}
-{{- if .Values.applications.miniflux.enabled }}
+{{- if (include "app.enabled" (list . "miniflux")) }}
             - name: miniflux
               password:
                 type: AlphaNumeric
               databases:
                 - miniflux
 {{- end }}
-{{- if .Values.applications.n8n.enabled }}
+{{- if (include "app.enabled" (list . "n8n")) }}
             - name: n8n
               databases:
                 - n8n
 {{- end }}
-{{- if .Values.applications.netbox.enabled }}
+{{- if (include "app.enabled" (list . "netbox")) }}
             - name: netbox
               databases:
                 - netbox
 {{- end }}
-{{- if .Values.applications.nextcloud.enabled }}
+{{- if (include "app.enabled" (list . "nextcloud")) }}
             - name: nextcloud
               databases:
                 - nextcloud
 {{- end }}
-{{- if .Values.applications.obico.enabled }}
+{{- if (include "app.enabled" (list . "obico")) }}
             - name: obico
               password:
                 type: AlphaNumeric
               databases:
                 - obico
 {{- end }}
-{{- if .Values.applications.odoo.enabled }}
+{{- if (include "app.enabled" (list . "odoo")) }}
             - name: odoo
               databases:
                 - odoo
 {{- end }}
-{{- if .Values.applications.open_webui.enabled }}
+{{- if (include "app.enabled" (list . "open_webui")) }}
             - name: open-webui
               databases:
                 - open-webui
 {{- end }}
-{{- if .Values.applications.pgadmin4.enabled }}
+{{- if (include "app.enabled" (list . "pgadmin4")) }}
             - name: pgadmin4
               password:
                 type: AlphaNumeric
               databases:
                 - pgadmin4
 {{- end }}
-{{- if .Values.applications.prowlarr.enabled }}
+{{- if (include "app.enabled" (list . "prowlarr")) }}
             - name: prowlarr
               databases:
                 - prowlarr_log
                 - prowlarr_main
 {{- end }}
-{{- if .Values.applications.radarr.enabled }}
+{{- if (include "app.enabled" (list . "radarr")) }}
             - name: radarr
               databases:
                 - radarr_log
                 - radarr_main
 {{- end }}
-{{- if .Values.applications.sonarr.enabled }}
+{{- if (include "app.enabled" (list . "sonarr")) }}
             - name: sonarr
               databases:
                 - sonarr_log
                 - sonarr_main
 {{- end }}
-{{- if .Values.applications.speedtest_tracker.enabled }}
+{{- if (include "app.enabled" (list . "speedtest_tracker")) }}
             - name: speedtest-tracker
               databases:
                 - speedtest-tracker
 {{- end }}
-{{- if .Values.applications.stalwart.enabled }}
+{{- if (include "app.enabled" (list . "stalwart")) }}
             - name: stalwart
               databases:
                 - stalwart
 {{- end }}
-{{- if .Values.applications.tracearr.enabled }}
+{{- if (include "app.enabled" (list . "tracearr")) }}
             - name: tracearr
               password:
                 type: AlphaNumeric
               databases:
                 - tracearr
 {{- end }}
-{{- if .Values.applications.vaultwarden.enabled }}
+{{- if (include "app.enabled" (list . "vaultwarden")) }}
             - name: vaultwarden
               password:
                 type: AlphaNumeric
               databases:
                 - vaultwarden
 {{- end }}
-{{- if .Values.applications.wakapi.enabled }}
+{{- if (include "app.enabled" (list . "wakapi")) }}
             - name: wakapi
               databases:
                 - wakapi

--- a/charts/services/templates/prometheus.yaml
+++ b/charts/services/templates/prometheus.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.primaryTenant (not .Values.disableAllApplications) .Values.applications.prometheus.enabled }}
+{{- if and .Values.primaryTenant (include "app.enabled" (list . "prometheus")) }}
 # ---
 # apiVersion: v1
 # kind: Secret
@@ -56,7 +56,7 @@ spec:
     defaultRules:
       rules:
         windows: false
-{{- if .Values.applications.gotify.enabled }}
+{{- if include "app.enabled" (list . "gotify") }}
     alertmanager:
       alertmanagerSpec:
         retention: 336h # 2 weeks
@@ -83,9 +83,9 @@ spec:
     grafana:
       annotations:
         reloader.stakater.com/auto: "true"
-{{- if and (not .Values.disableAllApplications) (or .Values.applications.loki.enabled .Values.applications.tempo.enabled) }}
+{{- if or (include "app.enabled" (list . "loki")) (include "app.enabled" (list . "tempo")) }}
       additionalDataSources:
-{{- if .Values.applications.loki.enabled }}
+{{- if include "app.enabled" (list . "loki") }}
         - name: Loki
           type: loki
           uid: loki
@@ -96,7 +96,7 @@ spec:
             timeout: 60
             maxLines: 1000
 {{- end }}
-{{- if .Values.applications.tempo.enabled }}
+{{- if include "app.enabled" (list . "tempo") }}
         - name: Tempo
           uid: tempo
           type: tempo
@@ -184,24 +184,24 @@ spec:
             datasource:
               - name: DS_PROMETHEUS
                 value: Prometheus
-{{- if .Values.applications.argo.enabled }}
+{{- if include "app.enabled" (list . "argo") }}
           argo-cd:
             gnetId: 14584
             revision: 1
             datasource: Prometheus
 {{- end }}
-{{- if or .Values.applications.prowlarr.enabled .Values.applications.radarr.enabled .Values.applications.sonarr.enabled }}
+{{- if or (include "app.enabled" (list . "prowlarr")) (include "app.enabled" (list . "radarr")) (include "app.enabled" (list . "sonarr")) }}
           arr:
             url: https://raw.githubusercontent.com/onedr0p/exportarr/3cd394508cf9456f8df4ce4a5d1adc33bb51da2b/examples/grafana/dashboard2.json
             datasource: Prometheus
 {{- end }}
-{{- if .Values.applications.authentik.enabled }}
+{{- if include "app.enabled" (list . "authentik") }}
           authentik:
             gnetId: 14837
             revision: 2
             datasource: Prometheus
 {{- end }}
-{{- if .Values.applications.crowdsec.enabled }}
+{{- if include "app.enabled" (list . "crowdsec") }}
           crowdsec:
             gnetId: 24049
             revision: 1
@@ -211,7 +211,7 @@ spec:
               - name: DS_LOKI
                 value: Loki
 {{- end }}
-{{- if .Values.applications.loki.enabled }}
+{{- if include "app.enabled" (list . "loki") }}
           loki:
             gnetId: 14055
             revision: 5
@@ -221,7 +221,7 @@ spec:
               - name: DS_LOKI
                 value: Loki
 {{- end }}
-{{- if .Values.applications.postgresql.enabled }}
+{{- if include "app.enabled" (list . "postgresql") }}
           pgbackrest:
             url: https://raw.githubusercontent.com/CrunchyData/postgres-operator-examples/6b9bb005f171690d228bf49ca19f8f4caff95451/kustomize/monitoring/grafana/dashboards/pgbackrest.json
             datasource: Prometheus
@@ -238,7 +238,7 @@ spec:
             url: https://raw.githubusercontent.com/CrunchyData/postgres-operator-examples/6b9bb005f171690d228bf49ca19f8f4caff95451/kustomize/monitoring/grafana/dashboards/query_statistics.json
             datasource: Prometheus
 {{- end }}
-{{- if .Values.applications.idrac_exporter.enabled }}
+{{- if include "app.enabled" (list . "idrac_exporter") }}
           bmc:
             url: https://raw.githubusercontent.com/mrlhansen/idrac_exporter/8d5d7e3da3d98f773dbfcc2709f21b1d3045f845/grafana/idrac.json
             datasource:
@@ -255,7 +255,7 @@ spec:
               - name: DS_PROMETHEUS
                 value: Prometheus
 {{- end }}
-{{- if .Values.applications.ipmi_exporter.enabled }}
+{{- if include "app.enabled" (list . "ipmi_exporter") }}
           ipmi:
             gnetId: 15765
             revision: 2
@@ -263,7 +263,7 @@ spec:
               - name: DS_PROMETHEUS
                 value: Prometheus
 {{- end }}
-{{- if .Values.applications.minio.enabled }}
+{{- if include "app.enabled" (list . "minio") }}
           minio:
             gnetId: 13502
             revision: 26
@@ -271,7 +271,7 @@ spec:
               - name: DS_PROMETHEUS
                 value: Prometheus
 {{- end }}
-{{- if .Values.applications.node_problem_detector.enabled }}
+{{- if include "app.enabled" (list . "node_problem_detector") }}
           node-problem-detector:
             gnetId: 15549
             revision: 1
@@ -279,7 +279,7 @@ spec:
               - name: DS_PROMETHEUS
                 value: Prometheus
 {{- end }}
-{{- if .Values.applications.redis.enabled }}
+{{- if include "app.enabled" (list . "redis") }}
           redis:
             gnetId: 763
             revision: 6
@@ -291,14 +291,14 @@ spec:
             revision: 1
             datasource: Prometheus
 {{- end }}
-{{- if .Values.applications.velero.enabled }}
+{{- if include "app.enabled" (list . "velero") }}
           velero:
             # gnetId: 23838
             gnetId: 15469
             revision: 1
             datasource: Prometheus
 {{- end }}
-{{- if .Values.applications.speedtest_tracker.enabled }}
+{{- if include "app.enabled" (list . "speedtest_tracker") }}
           speedtest_tracker:
             gnetId: 24608
             revision: 2
@@ -388,7 +388,7 @@ spec:
           requests:
             cpu: 500m
             memory: 1Gi
-{{- if .Values.applications.ipmi_exporter.enabled }}
+{{- if include "app.enabled" (list . "ipmi_exporter") }}
         secrets:
           - ipmi-exporter
 {{- end }}
@@ -430,7 +430,7 @@ spec:
       serviceMonitor:
         enabled: false
     extraManifests:
-{{- if .Values.applications.gotify.enabled }}
+{{- if include "app.enabled" (list . "gotify") }}
       - apiVersion: apps/v1
         kind: Deployment
         metadata:

--- a/charts/services/templates/prometheus.yaml
+++ b/charts/services/templates/prometheus.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.primaryTenant (not .Values.disableAllApplications) .Values.applications.prometheus.enabled }}
+{{- if and .Values.primaryTenant (include "app.enabled" (list . "prometheus")) }}
 # ---
 # apiVersion: v1
 # kind: Secret
@@ -56,7 +56,7 @@ spec:
     defaultRules:
       rules:
         windows: false
-{{- if .Values.applications.gotify.enabled }}
+{{- if (include "app.enabled" (list . "gotify")) }}
     alertmanager:
       alertmanagerSpec:
         retention: 336h # 2 weeks
@@ -83,9 +83,9 @@ spec:
     grafana:
       annotations:
         reloader.stakater.com/auto: "true"
-{{- if and (not .Values.disableAllApplications) (or .Values.applications.loki.enabled .Values.applications.tempo.enabled) }}
+{{- if or (include "app.enabled" (list . "loki")) (include "app.enabled" (list . "tempo")) }}
       additionalDataSources:
-{{- if .Values.applications.loki.enabled }}
+{{- if (include "app.enabled" (list . "loki")) }}
         - name: Loki
           type: loki
           uid: loki
@@ -96,7 +96,7 @@ spec:
             timeout: 60
             maxLines: 1000
 {{- end }}
-{{- if .Values.applications.tempo.enabled }}
+{{- if (include "app.enabled" (list . "tempo")) }}
         - name: Tempo
           uid: tempo
           type: tempo
@@ -184,24 +184,24 @@ spec:
             datasource:
               - name: DS_PROMETHEUS
                 value: Prometheus
-{{- if .Values.applications.argo.enabled }}
+{{- if (include "app.enabled" (list . "argo")) }}
           argo-cd:
             gnetId: 14584
             revision: 1
             datasource: Prometheus
 {{- end }}
-{{- if or .Values.applications.prowlarr.enabled .Values.applications.radarr.enabled .Values.applications.sonarr.enabled }}
+{{- if or (include "app.enabled" (list . "prowlarr")) (include "app.enabled" (list . "radarr")) (include "app.enabled" (list . "sonarr")) }}
           arr:
             url: https://raw.githubusercontent.com/onedr0p/exportarr/3cd394508cf9456f8df4ce4a5d1adc33bb51da2b/examples/grafana/dashboard2.json
             datasource: Prometheus
 {{- end }}
-{{- if .Values.applications.authentik.enabled }}
+{{- if (include "app.enabled" (list . "authentik")) }}
           authentik:
             gnetId: 14837
             revision: 2
             datasource: Prometheus
 {{- end }}
-{{- if .Values.applications.crowdsec.enabled }}
+{{- if (include "app.enabled" (list . "crowdsec")) }}
           crowdsec:
             gnetId: 24049
             revision: 1
@@ -211,7 +211,7 @@ spec:
               - name: DS_LOKI
                 value: Loki
 {{- end }}
-{{- if .Values.applications.loki.enabled }}
+{{- if (include "app.enabled" (list . "loki")) }}
           loki:
             gnetId: 14055
             revision: 5
@@ -221,7 +221,7 @@ spec:
               - name: DS_LOKI
                 value: Loki
 {{- end }}
-{{- if .Values.applications.postgresql.enabled }}
+{{- if (include "app.enabled" (list . "postgresql")) }}
           pgbackrest:
             url: https://raw.githubusercontent.com/CrunchyData/postgres-operator-examples/6b9bb005f171690d228bf49ca19f8f4caff95451/kustomize/monitoring/grafana/dashboards/pgbackrest.json
             datasource: Prometheus
@@ -238,7 +238,7 @@ spec:
             url: https://raw.githubusercontent.com/CrunchyData/postgres-operator-examples/6b9bb005f171690d228bf49ca19f8f4caff95451/kustomize/monitoring/grafana/dashboards/query_statistics.json
             datasource: Prometheus
 {{- end }}
-{{- if .Values.applications.idrac_exporter.enabled }}
+{{- if (include "app.enabled" (list . "idrac_exporter")) }}
           bmc:
             url: https://raw.githubusercontent.com/mrlhansen/idrac_exporter/8d5d7e3da3d98f773dbfcc2709f21b1d3045f845/grafana/idrac.json
             datasource:
@@ -255,7 +255,7 @@ spec:
               - name: DS_PROMETHEUS
                 value: Prometheus
 {{- end }}
-{{- if .Values.applications.ipmi_exporter.enabled }}
+{{- if (include "app.enabled" (list . "ipmi_exporter")) }}
           ipmi:
             gnetId: 15765
             revision: 2
@@ -263,7 +263,7 @@ spec:
               - name: DS_PROMETHEUS
                 value: Prometheus
 {{- end }}
-{{- if .Values.applications.minio.enabled }}
+{{- if (include "app.enabled" (list . "minio")) }}
           minio:
             gnetId: 13502
             revision: 26
@@ -271,7 +271,7 @@ spec:
               - name: DS_PROMETHEUS
                 value: Prometheus
 {{- end }}
-{{- if .Values.applications.node_problem_detector.enabled }}
+{{- if (include "app.enabled" (list . "node_problem_detector")) }}
           node-problem-detector:
             gnetId: 15549
             revision: 1
@@ -279,7 +279,7 @@ spec:
               - name: DS_PROMETHEUS
                 value: Prometheus
 {{- end }}
-{{- if .Values.applications.redis.enabled }}
+{{- if (include "app.enabled" (list . "redis")) }}
           redis:
             gnetId: 763
             revision: 6
@@ -291,14 +291,14 @@ spec:
             revision: 1
             datasource: Prometheus
 {{- end }}
-{{- if .Values.applications.velero.enabled }}
+{{- if (include "app.enabled" (list . "velero")) }}
           velero:
             # gnetId: 23838
             gnetId: 15469
             revision: 1
             datasource: Prometheus
 {{- end }}
-{{- if .Values.applications.speedtest_tracker.enabled }}
+{{- if (include "app.enabled" (list . "speedtest_tracker")) }}
           speedtest_tracker:
             gnetId: 24608
             revision: 2
@@ -388,7 +388,7 @@ spec:
           requests:
             cpu: 500m
             memory: 1Gi
-{{- if .Values.applications.ipmi_exporter.enabled }}
+{{- if (include "app.enabled" (list . "ipmi_exporter")) }}
         secrets:
           - ipmi-exporter
 {{- end }}
@@ -430,7 +430,7 @@ spec:
       serviceMonitor:
         enabled: false
     extraManifests:
-{{- if .Values.applications.gotify.enabled }}
+{{- if (include "app.enabled" (list . "gotify")) }}
       - apiVersion: apps/v1
         kind: Deployment
         metadata:

--- a/charts/services/templates/prowlarr.yaml
+++ b/charts/services/templates/prowlarr.yaml
@@ -1,8 +1,8 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.prowlarr.enabled }}
-{{- if not .Values.applications.postgresql.enabled }}
+{{- if include "app.enabled" (list . "prowlarr") }}
+{{- if not (include "app.enabled" (list . "postgresql")) }}
 {{- fail "Prowlarr requires PostgreSQL to be enabled. Please enable PostgreSQL in your values.yaml" }}
 {{- end }}
-{{- if not .Values.applications.gluetun.enabled }}
+{{- if not (include "app.enabled" (list . "gluetun")) }}
 {{- fail "Prowlarr requires gluetun to be enabled. Please enable gluetun in your values.yaml" }}
 {{- end }}
 # ---

--- a/charts/services/templates/prowlarr.yaml
+++ b/charts/services/templates/prowlarr.yaml
@@ -1,8 +1,8 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.prowlarr.enabled }}
-{{- if not .Values.applications.postgresql.enabled }}
+{{- if (include "app.enabled" (list . "prowlarr")) }}
+{{- if not (include "app.enabled" (list . "postgresql")) }}
 {{- fail "Prowlarr requires PostgreSQL to be enabled. Please enable PostgreSQL in your values.yaml" }}
 {{- end }}
-{{- if not .Values.applications.gluetun.enabled }}
+{{- if not (include "app.enabled" (list . "gluetun")) }}
 {{- fail "Prowlarr requires gluetun to be enabled. Please enable gluetun in your values.yaml" }}
 {{- end }}
 # ---

--- a/charts/services/templates/radarr.yaml
+++ b/charts/services/templates/radarr.yaml
@@ -1,5 +1,5 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.radarr.enabled }}
-{{- if not .Values.applications.postgresql.enabled }}
+{{- if include "app.enabled" (list . "radarr") }}
+{{- if not (include "app.enabled" (list . "postgresql")) }}
 {{- fail "Radarr requires PostgreSQL to be enabled. Please enable PostgreSQL in your values.yaml" }}
 {{- end }}
 ---

--- a/charts/services/templates/radarr.yaml
+++ b/charts/services/templates/radarr.yaml
@@ -1,5 +1,5 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.radarr.enabled }}
-{{- if not .Values.applications.postgresql.enabled }}
+{{- if (include "app.enabled" (list . "radarr")) }}
+{{- if not (include "app.enabled" (list . "postgresql")) }}
 {{- fail "Radarr requires PostgreSQL to be enabled. Please enable PostgreSQL in your values.yaml" }}
 {{- end }}
 ---

--- a/charts/services/templates/red.yaml
+++ b/charts/services/templates/red.yaml
@@ -1,4 +1,4 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.red.enabled }}
+{{- if include "app.enabled" (list . "red") }}
 # ---
 # apiVersion: v1
 # kind: Secret

--- a/charts/services/templates/red.yaml
+++ b/charts/services/templates/red.yaml
@@ -1,4 +1,4 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.red.enabled }}
+{{- if (include "app.enabled" (list . "red")) }}
 # ---
 # apiVersion: v1
 # kind: Secret

--- a/charts/services/templates/redis-insight.yaml
+++ b/charts/services/templates/redis-insight.yaml
@@ -1,5 +1,5 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.redis_insight.enabled }}
-{{- if not .Values.applications.redis.enabled }}
+{{- if include "app.enabled" (list . "redis_insight") }}
+{{- if not (include "app.enabled" (list . "redis")) }}
 {{- fail "Redis Insight requires Redis to be enabled. Please enable Redis in your values.yaml" }}
 {{- end }}
 ---

--- a/charts/services/templates/redis-insight.yaml
+++ b/charts/services/templates/redis-insight.yaml
@@ -1,5 +1,5 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.redis_insight.enabled }}
-{{- if not .Values.applications.redis.enabled }}
+{{- if (include "app.enabled" (list . "redis_insight")) }}
+{{- if not (include "app.enabled" (list . "redis")) }}
 {{- fail "Redis Insight requires Redis to be enabled. Please enable Redis in your values.yaml" }}
 {{- end }}
 ---

--- a/charts/services/templates/redis.yaml
+++ b/charts/services/templates/redis.yaml
@@ -1,4 +1,4 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.redis.enabled }}
+{{- if include "app.enabled" (list . "redis") }}
 ---
 apiVersion: helm.cattle.io/v1
 kind: HelmChart

--- a/charts/services/templates/redis.yaml
+++ b/charts/services/templates/redis.yaml
@@ -1,4 +1,4 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.redis.enabled }}
+{{- if (include "app.enabled" (list . "redis")) }}
 ---
 apiVersion: helm.cattle.io/v1
 kind: HelmChart

--- a/charts/services/templates/sonarr.yaml
+++ b/charts/services/templates/sonarr.yaml
@@ -1,5 +1,5 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.sonarr.enabled }}
-{{- if not .Values.applications.postgresql.enabled }}
+{{- if include "app.enabled" (list . "sonarr") }}
+{{- if not (include "app.enabled" (list . "postgresql")) }}
 {{- fail "Sonarr requires PostgreSQL to be enabled. Please enable PostgreSQL in your values.yaml" }}
 {{- end }}
 ---

--- a/charts/services/templates/sonarr.yaml
+++ b/charts/services/templates/sonarr.yaml
@@ -1,5 +1,5 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.sonarr.enabled }}
-{{- if not .Values.applications.postgresql.enabled }}
+{{- if (include "app.enabled" (list . "sonarr")) }}
+{{- if not (include "app.enabled" (list . "postgresql")) }}
 {{- fail "Sonarr requires PostgreSQL to be enabled. Please enable PostgreSQL in your values.yaml" }}
 {{- end }}
 ---

--- a/charts/services/templates/speedtest-tracker.yaml
+++ b/charts/services/templates/speedtest-tracker.yaml
@@ -1,8 +1,8 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.speedtest_tracker.enabled }}
-{{- if not .Values.applications.postgresql.enabled }}
+{{- if include "app.enabled" (list . "speedtest_tracker") }}
+{{- if not (include "app.enabled" (list . "postgresql")) }}
 {{- fail "Speedtest Tracker requires PostgreSQL to be enabled. Please enable PostgreSQL in your values.yaml" }}
 {{- end }}
-{{- if not .Values.applications.redis.enabled }}
+{{- if not (include "app.enabled" (list . "redis")) }}
 {{- fail "Speedtest Tracker requires Redis to be enabled. Please enable Redis in your values.yaml" }}
 {{- end }}
 # ---

--- a/charts/services/templates/speedtest-tracker.yaml
+++ b/charts/services/templates/speedtest-tracker.yaml
@@ -1,8 +1,8 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.speedtest_tracker.enabled }}
-{{- if not .Values.applications.postgresql.enabled }}
+{{- if (include "app.enabled" (list . "speedtest_tracker")) }}
+{{- if not (include "app.enabled" (list . "postgresql")) }}
 {{- fail "Speedtest Tracker requires PostgreSQL to be enabled. Please enable PostgreSQL in your values.yaml" }}
 {{- end }}
-{{- if not .Values.applications.redis.enabled }}
+{{- if not (include "app.enabled" (list . "redis")) }}
 {{- fail "Speedtest Tracker requires Redis to be enabled. Please enable Redis in your values.yaml" }}
 {{- end }}
 # ---

--- a/charts/services/templates/stalwart.yaml
+++ b/charts/services/templates/stalwart.yaml
@@ -1,11 +1,11 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.stalwart.enabled }}
-{{- if not .Values.applications.postgresql.enabled }}
+{{- if include "app.enabled" (list . "stalwart") }}
+{{- if not (include "app.enabled" (list . "postgresql")) }}
 {{- fail "Stalwart requires PostgreSQL to be enabled. Please enable PostgreSQL in your values.yaml" }}
 {{- end }}
-{{- if not .Values.applications.authentik.enabled }}
+{{- if not (include "app.enabled" (list . "authentik")) }}
 {{- fail "Stalwart requires Authentik to be enabled. Please enable Authentik in your values.yaml" }}
 {{- end }}
-{{- if not .Values.applications.minio.enabled }}
+{{- if not (include "app.enabled" (list . "minio")) }}
 {{- fail "Stalwart requires MinIO to be enabled. Please enable MinIO in your values.yaml" }}
 {{- end }}
 
@@ -339,7 +339,7 @@ spec:
           level: trace
           enable:
             log-exporter: false
-            span-exporter: {{ .Values.applications.tempo.enabled }}
+            span-exporter: {{ include "app.enabled" (list . "tempo") }}
           transport: http
           endpoint: http://tempo.kube-system.svc.cluster.local:4318/v1/traces
       metrics:

--- a/charts/services/templates/stalwart.yaml
+++ b/charts/services/templates/stalwart.yaml
@@ -1,11 +1,11 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.stalwart.enabled }}
-{{- if not .Values.applications.postgresql.enabled }}
+{{- if (include "app.enabled" (list . "stalwart")) }}
+{{- if not (include "app.enabled" (list . "postgresql")) }}
 {{- fail "Stalwart requires PostgreSQL to be enabled. Please enable PostgreSQL in your values.yaml" }}
 {{- end }}
-{{- if not .Values.applications.authentik.enabled }}
+{{- if not (include "app.enabled" (list . "authentik")) }}
 {{- fail "Stalwart requires Authentik to be enabled. Please enable Authentik in your values.yaml" }}
 {{- end }}
-{{- if not .Values.applications.minio.enabled }}
+{{- if not (include "app.enabled" (list . "minio")) }}
 {{- fail "Stalwart requires MinIO to be enabled. Please enable MinIO in your values.yaml" }}
 {{- end }}
 
@@ -339,7 +339,7 @@ spec:
           level: trace
           enable:
             log-exporter: false
-            span-exporter: {{ .Values.applications.tempo.enabled }}
+            span-exporter: {{ (include "app.enabled" (list . "tempo")) }}
           transport: http
           endpoint: http://tempo.kube-system.svc.cluster.local:4318/v1/traces
       metrics:

--- a/charts/services/templates/tdarr.yaml
+++ b/charts/services/templates/tdarr.yaml
@@ -1,4 +1,4 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.tdarr.enabled }}
+{{- if include "app.enabled" (list . "tdarr") }}
 ---
 apiVersion: v1
 kind: Service
@@ -183,24 +183,24 @@ spec:
               cpu: 250m
             limits:
               memory: 2Gi
-              {{- $gpuVendor := .Values.applications.tdarr.gpu_vendor }}
+              {{- $gpuVendor := index (.Values.applications.tdarr | default dict) "gpu_vendor" }}
               {{- if eq $gpuVendor "intel" }}
-                {{- if not .Values.applications.intel_gpu.enabled }}
+                {{- if not (include "app.enabled" (list . "intel_gpu")) }}
                   {{- fail "Intel GPU is selected for Tdarr but intel_gpu is not enabled" }}
                 {{- end }}
               gpu.intel.com/i915: 1
               {{- else if eq $gpuVendor "intel_xe" }}
-                {{- if not .Values.applications.intel_gpu.enabled }}
+                {{- if not (include "app.enabled" (list . "intel_gpu")) }}
                   {{- fail "Intel GPU is selected for Jellyfin but intel_gpu is not enabled" }}
                 {{- end }}
               gpu.intel.com/xe: 1
               {{- else if eq $gpuVendor "nvidia" }}
-                {{- if not .Values.applications.nvidia_gpu.enabled }}
+                {{- if not (include "app.enabled" (list . "nvidia_gpu")) }}
                   {{- fail "NVIDIA GPU is selected for Tdarr but nvidia_gpu is not enabled" }}
                 {{- end }}
               nvidia.com/gpu: 1
               {{- else if eq $gpuVendor "amd" }}
-                {{- if not .Values.applications.amd_gpu.enabled }}
+                {{- if not (include "app.enabled" (list . "amd_gpu")) }}
                   {{- fail "AMD GPU is selected for Tdarr but amd_gpu is not enabled" }}
                 {{- end }}
               amd.com/gpu: 1

--- a/charts/services/templates/tdarr.yaml
+++ b/charts/services/templates/tdarr.yaml
@@ -1,4 +1,4 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.tdarr.enabled }}
+{{- if (include "app.enabled" (list . "tdarr")) }}
 ---
 apiVersion: helm.cattle.io/v1
 kind: HelmChart
@@ -126,22 +126,22 @@ spec:
                   cpu: null
                   {{- $gpuVendor := .Values.applications.tdarr.gpu_vendor }}
                   {{- if eq $gpuVendor "intel" }}
-                    {{- if not .Values.applications.intel_gpu.enabled }}
+                    {{- if not (include "app.enabled" (list . "intel_gpu")) }}
                       {{- fail "Intel GPU is selected for Tdarr but intel_gpu is not enabled" }}
                     {{- end }}
                   gpu.intel.com/i915: 1
                   {{- else if eq $gpuVendor "intel_xe" }}
-                    {{- if not .Values.applications.intel_gpu.enabled }}
+                    {{- if not (include "app.enabled" (list . "intel_gpu")) }}
                       {{- fail "Intel GPU is selected for Tdarr but intel_gpu is not enabled" }}
                     {{- end }}
                   gpu.intel.com/xe: 1
                   {{- else if eq $gpuVendor "nvidia" }}
-                    {{- if not .Values.applications.nvidia_gpu.enabled }}
+                    {{- if not (include "app.enabled" (list . "nvidia_gpu")) }}
                       {{- fail "NVIDIA GPU is selected for Tdarr but nvidia_gpu is not enabled" }}
                     {{- end }}
                   nvidia.com/gpu: 1
                   {{- else if eq $gpuVendor "amd" }}
-                    {{- if not .Values.applications.amd_gpu.enabled }}
+                    {{- if not (include "app.enabled" (list . "amd_gpu")) }}
                       {{- fail "AMD GPU is selected for Tdarr but amd_gpu is not enabled" }}
                     {{- end }}
                   amd.com/gpu: 1

--- a/charts/services/templates/tempo.yaml
+++ b/charts/services/templates/tempo.yaml
@@ -1,8 +1,8 @@
-{{- if and .Values.primaryTenant (not .Values.disableAllApplications) .Values.applications.tempo.enabled }}
-{{- if not .Values.applications.prometheus.enabled }}
+{{- if and .Values.primaryTenant (include "app.enabled" (list . "tempo")) }}
+{{- if not (include "app.enabled" (list . "prometheus")) }}
 {{- fail "Tempo requires Prometheus to be enabled. Please enable Prometheus in your values.yaml" }}
 {{- end }}
-{{- if not .Values.applications.minio.enabled }}
+{{- if not (include "app.enabled" (list . "minio")) }}
 {{- fail "Tempo requires MinIO to be enabled. Please enable MinIO in your values.yaml" }}
 {{- end }}
 # ---

--- a/charts/services/templates/tempo.yaml
+++ b/charts/services/templates/tempo.yaml
@@ -1,8 +1,8 @@
-{{- if and .Values.primaryTenant (not .Values.disableAllApplications) .Values.applications.tempo.enabled }}
-{{- if not .Values.applications.prometheus.enabled }}
+{{- if and .Values.primaryTenant  (include "app.enabled" (list . "tempo")) }}
+{{- if not (include "app.enabled" (list . "prometheus")) }}
 {{- fail "Tempo requires Prometheus to be enabled. Please enable Prometheus in your values.yaml" }}
 {{- end }}
-{{- if not .Values.applications.minio.enabled }}
+{{- if not (include "app.enabled" (list . "minio")) }}
 {{- fail "Tempo requires MinIO to be enabled. Please enable MinIO in your values.yaml" }}
 {{- end }}
 # ---

--- a/charts/services/templates/tracearr.yaml
+++ b/charts/services/templates/tracearr.yaml
@@ -1,8 +1,8 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.tracearr.enabled }}
-{{- if not .Values.applications.postgresql.enabled }}
+{{- if include "app.enabled" (list . "tracearr") }}
+{{- if not (include "app.enabled" (list . "postgresql")) }}
 {{- fail "Tracearr requires PostgreSQL to be enabled. Please enable PostgreSQL in your values.yaml" }}
 {{- end }}
-{{- if not .Values.applications.redis.enabled }}
+{{- if not (include "app.enabled" (list . "redis")) }}
 {{- fail "Tracearr requires Redis to be enabled. Please enable Redis in your values.yaml" }}
 {{- end }}
 ---

--- a/charts/services/templates/tracearr.yaml
+++ b/charts/services/templates/tracearr.yaml
@@ -1,8 +1,8 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.tracearr.enabled }}
-{{- if not .Values.applications.postgresql.enabled }}
+{{- if (include "app.enabled" (list . "tracearr")) }}
+{{- if not (include "app.enabled" (list . "postgresql")) }}
 {{- fail "Tracearr requires PostgreSQL to be enabled. Please enable PostgreSQL in your values.yaml" }}
 {{- end }}
-{{- if not .Values.applications.redis.enabled }}
+{{- if not (include "app.enabled" (list . "redis")) }}
 {{- fail "Tracearr requires Redis to be enabled. Please enable Redis in your values.yaml" }}
 {{- end }}
 ---

--- a/charts/services/templates/traefik.yaml
+++ b/charts/services/templates/traefik.yaml
@@ -62,7 +62,7 @@ spec:
           ipAllowList:
             sourceRange:
               {{- include "ip.private_ranges" . | nindent 14 }}
-{{- if and (not .Values.disableAllApplications) .Values.applications.crowdsec.enabled }}
+{{- if include "app.enabled" (list . "crowdsec") }}
       - apiVersion: traefik.io/v1alpha1
         kind: Middleware
         metadata:
@@ -115,7 +115,7 @@ spec:
           enabled: {{ include "metrics.enabled" . }}
         serviceMonitor:
           enabled: {{ include "metrics.enabled" . }}
-{{- if and (not .Values.disableAllApplications) .Values.applications.tempo.enabled }}
+{{- if include "app.enabled" (list . "tempo") }}
     tracing:
       capturedRequestHeaders:
         - "X-Real-Ip"
@@ -203,7 +203,7 @@ spec:
           middlewares:
             - kube-system-traefik-redirect-www@kubernetescrd
             - kube-system-traefik-websecure@kubernetescrd
-{{- if and (not .Values.disableAllApplications) .Values.applications.crowdsec.enabled }}
+{{- if include "app.enabled" (list . "crowdsec") }}
             - kube-system-crowdsec@kubernetescrd
 {{- end }}
           tls:

--- a/charts/services/templates/traefik.yaml
+++ b/charts/services/templates/traefik.yaml
@@ -62,7 +62,7 @@ spec:
           ipAllowList:
             sourceRange:
               {{- include "ip.private_ranges" . | nindent 14 }}
-{{- if and (not .Values.disableAllApplications) .Values.applications.crowdsec.enabled }}
+{{- if (include "app.enabled" (list . "crowdsec")) }}
       - apiVersion: traefik.io/v1alpha1
         kind: Middleware
         metadata:
@@ -115,7 +115,7 @@ spec:
           enabled: {{ include "metrics.enabled" . }}
         serviceMonitor:
           enabled: {{ include "metrics.enabled" . }}
-{{- if and (not .Values.disableAllApplications) .Values.applications.tempo.enabled }}
+{{- if (include "app.enabled" (list . "tempo")) }}
     tracing:
       capturedRequestHeaders:
         - "X-Real-Ip"
@@ -203,7 +203,7 @@ spec:
           middlewares:
             - kube-system-traefik-redirect-www@kubernetescrd
             - kube-system-traefik-websecure@kubernetescrd
-{{- if and (not .Values.disableAllApplications) .Values.applications.crowdsec.enabled }}
+{{- if (include "app.enabled" (list . "crowdsec")) }}
             - kube-system-crowdsec@kubernetescrd
 {{- end }}
           tls:

--- a/charts/services/templates/transmission.yaml
+++ b/charts/services/templates/transmission.yaml
@@ -1,5 +1,5 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.transmission.enabled }}
-{{- if not .Values.applications.gluetun.enabled }}
+{{- if include "app.enabled" (list . "transmission") }}
+{{- if not (include "app.enabled" (list . "gluetun")) }}
 {{- fail "Transmission requires gluetun to be enabled. Please enable gluetun in your values.yaml" }}
 {{- end }}
 # ---

--- a/charts/services/templates/transmission.yaml
+++ b/charts/services/templates/transmission.yaml
@@ -1,5 +1,5 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.transmission.enabled }}
-{{- if not .Values.applications.gluetun.enabled }}
+{{- if (include "app.enabled" (list . "transmission")) }}
+{{- if not (include "app.enabled" (list . "gluetun")) }}
 {{- fail "Transmission requires gluetun to be enabled. Please enable gluetun in your values.yaml" }}
 {{- end }}
 # ---

--- a/charts/services/templates/valheim.yaml
+++ b/charts/services/templates/valheim.yaml
@@ -1,4 +1,4 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.valheim.enabled }}
+{{- if (include "app.enabled" (list . "valheim")) }}
 # ---
 # apiVersion: v1
 # kind: Secret

--- a/charts/services/templates/vaultwarden.yaml
+++ b/charts/services/templates/vaultwarden.yaml
@@ -1,8 +1,8 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.vaultwarden.enabled }}
-{{- if not .Values.applications.postgresql.enabled }}
+{{- if (include "app.enabled" (list . "vaultwarden")) }}
+{{- if not (include "app.enabled" (list . "postgresql")) }}
 {{- fail "Vaultwarden requires PostgreSQL to be enabled. Please enable PostgreSQL in your values.yaml" }}
 {{- end }}
-{{- if not .Values.applications.authentik.enabled }}
+{{- if not (include "app.enabled" (list . "authentik")) }}
 {{- fail "Vaultwarden requires Authentik to be enabled. Please enable Authentik in your values.yaml" }}
 {{- end }}
 ---

--- a/charts/services/templates/velero.yaml
+++ b/charts/services/templates/velero.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.primaryTenant (not .Values.disableAllApplications) .Values.applications.velero.enabled }}
+{{- if and .Values.primaryTenant (include "app.enabled" (list . "velero")) }}
 # ---
 # apiVersion: v1
 # kind: Secret

--- a/charts/services/templates/velero.yaml
+++ b/charts/services/templates/velero.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.primaryTenant (not .Values.disableAllApplications) .Values.applications.velero.enabled }}
+{{- if and .Values.primaryTenant  (include "app.enabled" (list . "velero")) }}
 # ---
 # apiVersion: v1
 # kind: Secret

--- a/charts/services/templates/wakapi.yaml
+++ b/charts/services/templates/wakapi.yaml
@@ -1,5 +1,5 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.wakapi.enabled }}
-{{- if not .Values.applications.postgresql.enabled }}
+{{- if include "app.enabled" (list . "wakapi") }}
+{{- if not (include "app.enabled" (list . "postgresql")) }}
 {{- fail "Wakapi requires PostgreSQL to be enabled. Please enable PostgreSQL in your values.yaml" }}
 {{- end }}
 ---
@@ -33,7 +33,7 @@ spec:
                     expandObjectName: false
                 WAKAPI_INSECURE_COOKIES: "false"
                 WAKAPI_INVITE_CODES: "false"
-{{- if .Values.applications.authentik.enabled }}
+{{- if include "app.enabled" (list . "authentik") }}
                 WAKAPI_ALLOW_SIGNUP: "false"
                 WAKAPI_OIDC_ALLOW_SIGNUP: "true"
                 WAKAPI_OIDC_PROVIDERS_0_NAME: authentik
@@ -108,7 +108,7 @@ spec:
         enabled: false
     configmap:
       authentik-blueprint:
-        enabled: {{ and .Values.applications.wakapi.enabled (not .Values.applications.wakapi.trusted_header_auth) }}
+        enabled: {{ and (include "app.enabled" (list . "wakapi")) (not .Values.applications.wakapi.trusted_header_auth) }}
         data:
           blueprint.yaml: |
             # yaml-language-server: $schema=https://goauthentik.io/blueprints/schema.json

--- a/charts/services/templates/wakapi.yaml
+++ b/charts/services/templates/wakapi.yaml
@@ -1,5 +1,5 @@
-{{- if and (not .Values.disableAllApplications) .Values.applications.wakapi.enabled }}
-{{- if not .Values.applications.postgresql.enabled }}
+{{- if (include "app.enabled" (list . "wakapi")) }}
+{{- if not (include "app.enabled" (list . "postgresql")) }}
 {{- fail "Wakapi requires PostgreSQL to be enabled. Please enable PostgreSQL in your values.yaml" }}
 {{- end }}
 ---
@@ -33,7 +33,7 @@ spec:
                     expandObjectName: false
                 WAKAPI_INSECURE_COOKIES: "false"
                 WAKAPI_INVITE_CODES: "false"
-{{- if .Values.applications.authentik.enabled }}
+{{- if (include "app.enabled" (list . "authentik")) }}
                 WAKAPI_ALLOW_SIGNUP: "false"
                 WAKAPI_OIDC_ALLOW_SIGNUP: "true"
                 WAKAPI_OIDC_PROVIDERS_0_NAME: authentik
@@ -108,7 +108,7 @@ spec:
         enabled: false
     configmap:
       authentik-blueprint:
-        enabled: {{ and .Values.applications.wakapi.enabled (not .Values.applications.wakapi.trusted_header_auth) }}
+        enabled: {{ and (include "app.enabled" (list . "wakapi")) (not .Values.applications.wakapi.trusted_header_auth) }}
         data:
           blueprint.yaml: |
             # yaml-language-server: $schema=https://goauthentik.io/blueprints/schema.json

--- a/charts/services/tests/app_enabled_test.yaml
+++ b/charts/services/tests/app_enabled_test.yaml
@@ -1,0 +1,34 @@
+suite: app.enabled helper
+templates:
+  - templates/redis.yaml
+
+tests:
+  - it: renders when enableAllApplicationsByDefault is true and no per-app override
+    set:
+      enableAllApplicationsByDefault: true
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  - it: does not render when enableAllApplicationsByDefault is false and no per-app override
+    set:
+      enableAllApplicationsByDefault: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders when per-app enabled is true despite global false
+    set:
+      enableAllApplicationsByDefault: false
+      applications.redis.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  - it: does not render when per-app enabled is false despite global true
+    set:
+      enableAllApplicationsByDefault: true
+      applications.redis.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/services/values.yaml
+++ b/charts/services/values.yaml
@@ -57,7 +57,7 @@ cloudFlareIpRanges:
   - 2a06:98c0::/29
   - 2c0f:f248::/32
 
-disableAllApplications: false
+enableAllApplicationsByDefault: true
 
 # Global high availability configuration
 # Set to false to use 1 replica instead of 3 for services that support HA
@@ -65,17 +65,17 @@ highAvailability: true
 
 applications:
   akri:
-    enabled: true
+    # enabled: true
     udevRules: []
       # - 'KERNEL=="ttyUSB[0-9]*", ENV{ID_VENDOR}=="ABCDEFGH"'
   alloy:
-    enabled: true
+    # enabled: true
   amd_gpu:
-    enabled: true
+    # enabled: true
   archivebox:
-    enabled: true
+    # enabled: true
   argo:
-    enabled: true
+    # enabled: true
     # The git repository out of which to continuously deploy
     gitRepo: https://github.com/arch-anes/self-hosted-services.git
     targetRevision: HEAD
@@ -86,94 +86,95 @@ applications:
         timezone: "America/New_York"
         manualSync: true
   authentik:
-    enabled: true
+    # enabled: true
   bazarr:
-    enabled: true
+    # enabled: true
   crowdsec:
-    enabled: true
+    # enabled: true
   ddclient:
-    enabled: true
+    # enabled: true
   descheduler:
-    enabled: true
+    # enabled: true
   epicgames_freegames:
-    enabled: true
+    # enabled: true
   filebrowser:
-    enabled: true
+    # enabled: true
   flaresolverr:
-    enabled: true
+    # enabled: true
   gluetun:
-    enabled: true
+    # enabled: true
   gotify:
-    enabled: true
+    # enabled: true
   headlamp:
-    enabled: true
+    # enabled: true
   home_assistant:
-    enabled: true
+    # enabled: true
   homer_operator:
-    enabled: true
+    # enabled: true
   idrac_exporter:
-    enabled: true
+    # enabled: true
   immich:
-    enabled: true
+    # enabled: true
+    trusted_header_auth: false
     # gpu_vendor: nvidia
     # machine_learning:
     #   gpu_vendor: nvidia
   intel_gpu:
-    enabled: true
+    # enabled: true
   inventree:
-    enabled: true
+    # enabled: true
   ipmi_exporter:
-    enabled: true
+    # enabled: true
   jellyfin:
-    enabled: true
+    # enabled: true
     # gpu_vendor: intel
   jellyseerr:
-    enabled: true
+    # enabled: true
   joal:
-    enabled: true
+    # enabled: true
   lazylibrarian:
-    enabled: true
+    # enabled: true
   llama_cpp:
-    enabled: true
+    # enabled: true
     use_vulkan: false
     # gpu_vendor: null
     gpu_count: 1
     max_loaded_models: 1
   loki:
-    enabled: true
+    # enabled: true
   minecraft_bedrock:
-    enabled: true
+    # enabled: true
   miniflux:
-    enabled: true
+    # enabled: true
   minio:
-    enabled: true
+    # enabled: true
   mosquitto:
-    enabled: true
+    # enabled: true
   n8n:
-    enabled: true
+    # enabled: true
   netbox:
-    enabled: true
+    # enabled: true
   nextcloud:
-    enabled: true
+    # enabled: true
   node_problem_detector:
-    enabled: true
+    # enabled: true
   nvidia_gpu:
-    enabled: true
+    # enabled: true
   obico:
-    enabled: true
+    # enabled: true
   octoprint:
-    enabled: true
+    # enabled: true
     devices: []
       # - "akri.sh/akri-udev-abcdefgh"
   odoo:
-    enabled: true
+    # enabled: true
     updatePluginsOnStartup: false
   open_webui:
-    enabled: true
+    # enabled: true
   pgadmin4:
-    enabled: true
+    # enabled: true
   postgresql:
-    enabled: true
+    # enabled: true
     additionalUsers:
       - name: exampleUser1
     remoteBackupLocation:
@@ -182,36 +183,36 @@ applications:
         endpoint: "some-endpoint"
         region: "some-region"
   prometheus:
-    enabled: true
+    # enabled: true
   prowlarr:
-    enabled: true
+    # enabled: true
   radarr:
-    enabled: true
+    # enabled: true
   red:
-    enabled: true
+    # enabled: true
   redis:
-    enabled: true
+    # enabled: true
   redis_insight:
-    enabled: true
+    # enabled: true
   sonarr:
-    enabled: true
+    # enabled: true
   speedtest_tracker:
-    enabled: true
+    # enabled: true
     dashboard:
       enabled: true
   stalwart:
-    enabled: true
+    # enabled: true
   tdarr:
-    enabled: true
+    # enabled: true
     # gpu_vendor: amd
   tempo:
-    enabled: true
+    # enabled: true
   tracearr:
-    enabled: true
+    # enabled: true
   transmission:
-    enabled: true
+    # enabled: true
   velero:
-    enabled: true
+    # enabled: true
     remoteBackupLocations:
       - name: default
         default: true
@@ -223,4 +224,5 @@ applications:
           region: <some_region>
           s3Url: https://<some_endpoint> # if using an S3-compatible service
   wakapi:
-    enabled: true
+    # enabled: true
+    trusted_header_auth: false

--- a/charts/services/values.yaml
+++ b/charts/services/values.yaml
@@ -57,7 +57,7 @@ cloudFlareIpRanges:
   - 2a06:98c0::/29
   - 2c0f:f248::/32
 
-disableAllApplications: false
+enableAllApplicationsByDefault: true
 
 # Global high availability configuration
 # Set to false to use 1 replica instead of 3 for services that support HA
@@ -65,17 +65,17 @@ highAvailability: true
 
 applications:
   akri:
-    enabled: true
+    # enabled: true
     udevRules: []
       # - 'KERNEL=="ttyUSB[0-9]*", ENV{ID_VENDOR}=="ABCDEFGH"'
-  alloy:
-    enabled: true
-  amd_gpu:
-    enabled: true
-  archivebox:
-    enabled: true
+  alloy: {}
+    # enabled: true
+  amd_gpu: {}
+    # enabled: true
+  archivebox: {}
+    # enabled: true
   argo:
-    enabled: true
+    # enabled: true
     # The git repository out of which to continuously deploy
     gitRepo: https://github.com/arch-anes/self-hosted-services.git
     targetRevision: HEAD
@@ -85,95 +85,95 @@ applications:
         duration: "12h"
         timezone: "America/New_York"
         manualSync: true
-  authentik:
-    enabled: true
-  bazarr:
-    enabled: true
-  crowdsec:
-    enabled: true
-  ddclient:
-    enabled: true
-  descheduler:
-    enabled: true
-  epicgames_freegames:
-    enabled: true
-  filebrowser:
-    enabled: true
-  flaresolverr:
-    enabled: true
-  gluetun:
-    enabled: true
-  gotify:
-    enabled: true
-  headlamp:
-    enabled: true
-  home_assistant:
-    enabled: true
-  homer_operator:
-    enabled: true
-  idrac_exporter:
-    enabled: true
-  immich:
-    enabled: true
+  authentik: {}
+    # enabled: true
+  bazarr: {}
+    # enabled: true
+  crowdsec: {}
+    # enabled: true
+  ddclient: {}
+    # enabled: true
+  descheduler: {}
+    # enabled: true
+  epicgames_freegames: {}
+    # enabled: true
+  filebrowser: {}
+    # enabled: true
+  flaresolverr: {}
+    # enabled: true
+  gluetun: {}
+    # enabled: true
+  gotify: {}
+    # enabled: true
+  headlamp: {}
+    # enabled: true
+  home_assistant: {}
+    # enabled: true
+  homer_operator: {}
+    # enabled: true
+  idrac_exporter: {}
+    # enabled: true
+  immich: {}
+    # enabled: true
     # gpu_vendor: nvidia
     # machine_learning:
     #   gpu_vendor: nvidia
-  intel_gpu:
-    enabled: true
-  inventree:
-    enabled: true
-  ipmi_exporter:
-    enabled: true
-  jellyfin:
-    enabled: true
+  intel_gpu: {}
+    # enabled: true
+  inventree: {}
+    # enabled: true
+  ipmi_exporter: {}
+    # enabled: true
+  jellyfin: {}
+    # enabled: true
     # gpu_vendor: intel
-  jellyseerr:
-    enabled: true
-  joal:
-    enabled: true
-  lazylibrarian:
-    enabled: true
+  jellyseerr: {}
+    # enabled: true
+  joal: {}
+    # enabled: true
+  lazylibrarian: {}
+    # enabled: true
   llama_cpp:
-    enabled: true
+    # enabled: true
     use_vulkan: false
     # gpu_vendor: null
     gpu_count: 1
     max_loaded_models: 1
-  loki:
-    enabled: true
-  minecraft_bedrock:
-    enabled: true
-  miniflux:
-    enabled: true
-  minio:
-    enabled: true
-  mosquitto:
-    enabled: true
-  n8n:
-    enabled: true
-  netbox:
-    enabled: true
-  nextcloud:
-    enabled: true
-  node_problem_detector:
-    enabled: true
-  nvidia_gpu:
-    enabled: true
-  obico:
-    enabled: true
+  loki: {}
+    # enabled: true
+  minecraft_bedrock: {}
+    # enabled: true
+  miniflux: {}
+    # enabled: true
+  minio: {}
+    # enabled: true
+  mosquitto: {}
+    # enabled: true
+  n8n: {}
+    # enabled: true
+  netbox: {}
+    # enabled: true
+  nextcloud: {}
+    # enabled: true
+  node_problem_detector: {}
+    # enabled: true
+  nvidia_gpu: {}
+    # enabled: true
+  obico: {}
+    # enabled: true
   octoprint:
-    enabled: true
+    # enabled: true
     devices: []
       # - "akri.sh/akri-udev-abcdefgh"
   odoo:
-    enabled: true
+    # enabled: true
     updatePluginsOnStartup: false
-  open_webui:
-    enabled: true
-  pgadmin4:
-    enabled: true
+  open_webui: {}
+    # enabled: true
+  pgadmin4: {}
+    # enabled: true
   postgresql:
-    enabled: true
+    # enabled: true
     additionalUsers:
       - name: exampleUser1
     remoteBackupLocation:
@@ -181,41 +181,41 @@ applications:
         bucket: "some-bucket"
         endpoint: "some-endpoint"
         region: "some-region"
-  prometheus:
-    enabled: true
-  prowlarr:
-    enabled: true
-  radarr:
-    enabled: true
-  red:
-    enabled: true
-  redis:
-    enabled: true
-  redis_insight:
-    enabled: true
-  sonarr:
-    enabled: true
+  prometheus: {}
+    # enabled: true
+  prowlarr: {}
+    # enabled: true
+  radarr: {}
+    # enabled: true
+  red: {}
+    # enabled: true
+  redis: {}
+    # enabled: true
+  redis_insight: {}
+    # enabled: true
+  sonarr: {}
+    # enabled: true
   speedtest_tracker:
-    enabled: true
+    # enabled: true
     dashboard:
       enabled: true
-  stalwart:
-    enabled: true
-  tdarr:
-    enabled: true
+  stalwart: {}
+    # enabled: true
+  tdarr: {}
+    # enabled: true
     # gpu_vendor: amd
-  tempo:
-    enabled: true
-  tracearr:
-    enabled: true
-  transmission:
-    enabled: true
-  valheim:
-    enabled: true
-  vaultwarden:
-    enabled: true
+  tempo: {}
+    # enabled: true
+  tracearr: {}
+    # enabled: true
+  transmission: {}
+    # enabled: true
+  valheim: {}
+    # enabled: true
+  vaultwarden: {}
+    # enabled: true
   velero:
-    enabled: true
+    # enabled: true
     remoteBackupLocations:
       - name: default
         default: true
@@ -226,5 +226,5 @@ applications:
           s3ForcePathStyle: true # if using an S3-compatible service
           region: <some_region>
           s3Url: https://<some_endpoint> # if using an S3-compatible service
-  wakapi:
-    enabled: true
+  wakapi: {}
+    # enabled: true

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -71,7 +71,7 @@ provisioner:
         manifest_only_setup: false
         display_headlamp_token: false
         chartValuesOverrides:
-          disableAllApplications: true
+          enableAllApplicationsByDefault: false
           highAvailability: false 
     host_vars:
       replica1:


### PR DESCRIPTION
Introduces an app.enabled helper that respects a per-app enabled override if explicitly set, falling back to enableAllApplicationsByDefault otherwise. All 200+ .enabled references across templates now go through this helper. Adds helm-unittest tests covering the four-way global/per-app matrix.