### PR TITLE
Add network policies

### DIFF
--- a/charts/services/templates/flaresolverr.yaml
+++ b/charts/services/templates/flaresolverr.yaml
@@ -17,6 +17,8 @@ spec:
     workload:
       main:
         podSpec:
+          labels:
+            networking.arch-anes.io/egress: tunnel-only
           containers:
             {{- include "tunnel.truecharts.container" . | nindent 12 }}
             main:

--- a/charts/services/templates/frigate.yaml
+++ b/charts/services/templates/frigate.yaml
@@ -29,6 +29,8 @@ spec:
             nas: "true"
           annotations:
             backup.velero.io/backup-volumes: config
+          labels:
+            networking.arch-anes.io/egress: lan-access
           initContainers:
             init-config:
               enabled: true

--- a/charts/services/templates/home-assistant.yaml
+++ b/charts/services/templates/home-assistant.yaml
@@ -102,6 +102,8 @@ spec:
         podSpec:
           annotations:
             backup.velero.io/backup-volumes: config
+          labels:
+            networking.arch-anes.io/egress: lan-access
           containers:
             main:
               env:

--- a/charts/services/templates/joal.yaml
+++ b/charts/services/templates/joal.yaml
@@ -134,6 +134,7 @@ spec:
                 backup.velero.io/backup-volumes: config
               labels:
                 app: joal
+                networking.arch-anes.io/egress: tunnel-only
             spec:
               containers:
                 {{- include "tunnel.deployment.container" . | nindent 16 }}

--- a/charts/services/templates/network-policies.yaml
+++ b/charts/services/templates/network-policies.yaml
@@ -89,14 +89,20 @@ spec:
 
 ---
 # Keep external access available without permitting direct connections to pod
-# or Service addresses in other namespaces.
+# or Service addresses in other namespaces. The excluded ranges are the k3s
+# pod and Service CIDRs also used by the tunnel helper.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: allow-external-egress
   namespace: "{{ .Values.applicationsNamespace }}"
 spec:
-  podSelector: {}
+  podSelector:
+    matchExpressions:
+      - key: networking.arch-anes.io/egress
+        operator: NotIn
+        values:
+          - tunnel-only
   policyTypes:
     - Egress
   egress:
@@ -104,5 +110,7 @@ spec:
         - ipBlock:
             cidr: 0.0.0.0/0
             except:
-              - 10.42.0.0/16
-              - 10.43.0.0/16
+              {{- include "ip.private_ipv4_ranges" . | nindent 14 }}
+    - to:
+        - ipBlock:
+            cidr: 2000::/3

--- a/charts/services/templates/network-policies.yaml
+++ b/charts/services/templates/network-policies.yaml
@@ -1,0 +1,108 @@
+---
+# Isolate tenant workloads from other namespaces. Connections originating from
+# kube-system are allowed so cluster services, such as Prometheus, can scrape
+# application metrics. Responses to those connections are permitted by the
+# CNI's connection tracking and do not need an egress rule.
+#
+# Do not apply a blanket ingress deny policy to kube-system. Its workloads can
+# receive node-level and host-network traffic, whose sources cannot be reliably
+# selected by a standard NetworkPolicy. Protect sensitive kube-system workloads
+# individually instead.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: namespace-isolation
+  namespace: "{{ .Values.applicationsNamespace }}"
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector: {}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+
+---
+# Allow infrastructure access required by every workload: DNS through CoreDNS
+# and the Kubernetes API. Permit both the API Service address on TCP 443 and
+# TCP 6443 within the node network because Service translation can expose the
+# control-plane endpoint before NetworkPolicy evaluation.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-essential-services
+  namespace: "{{ .Values.applicationsNamespace }}"
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    - to:
+        - ipBlock:
+            cidr: 10.43.0.1/32
+      ports:
+        - port: 443
+          protocol: TCP
+    - to:
+      - ipBlock:
+          cidr: 192.168.0.0/16
+      ports:
+      - port: 6443
+        protocol: TCP
+
+---
+# NetworkPolicy rules are additive. Exclude restricted-local workloads from the
+# namespace-wide same-namespace egress rule so their own policies remain
+# restrictive.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: same-namespace-egress
+  namespace: "{{ .Values.applicationsNamespace }}"
+spec:
+  podSelector:
+    matchExpressions:
+      - key: networking.arch-anes.io/egress
+        operator: NotIn
+        values:
+          - restricted-local
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - podSelector: {}
+
+---
+# Keep external access available without permitting direct connections to pod
+# or Service addresses in other namespaces.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-external-egress
+  namespace: "{{ .Values.applicationsNamespace }}"
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.42.0.0/16
+              - 10.43.0.0/16

--- a/charts/services/templates/network-policies.yaml
+++ b/charts/services/templates/network-policies.yaml
@@ -114,3 +114,25 @@ spec:
     - to:
         - ipBlock:
             cidr: 2000::/3
+
+---
+# LAN access is only available to applications that need to communicate with
+# local devices. iDRAC and IPMI exporters run in kube-system and are outside
+# this application-namespace policy.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-lan-egress
+  namespace: "{{ .Values.applicationsNamespace }}"
+spec:
+  podSelector:
+    matchLabels:
+      networking.arch-anes.io/egress: lan-access
+  policyTypes:
+    - Egress
+  egress:
+    {{- range (concat .Values.localIpv4Ranges .Values.localIpv6Ranges) }}
+    - to:
+        - ipBlock:
+            cidr: {{ . }}
+    {{- end }}

--- a/charts/services/templates/octoprint.yaml
+++ b/charts/services/templates/octoprint.yaml
@@ -27,6 +27,8 @@ spec:
         podSpec:
           annotations:
             backup.velero.io/backup-volumes: data
+          labels:
+            networking.arch-anes.io/egress: lan-access
           containers:
             main:
               env:

--- a/charts/services/templates/open-webui.yaml
+++ b/charts/services/templates/open-webui.yaml
@@ -29,6 +29,8 @@ spec:
       enabled: false
       redis:
         enabled: false
+    podLabels:
+      networking.arch-anes.io/egress: restricted-local
     extraEnvVars:
       - name: WEBUI_SECRET_KEY
         valueFrom:
@@ -175,5 +177,30 @@ spec:
               rewrite:
                 - transform:
                     template: client_secret
+      - apiVersion: networking.k8s.io/v1
+        kind: NetworkPolicy
+        metadata:
+          name: open-webui-egress
+          namespace: "{{ .Values.applicationsNamespace }}"
+        spec:
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: open-webui
+          policyTypes:
+            - Egress
+          egress:
+            - to:
+                - podSelector:
+                    matchExpressions:
+                      - key: app.kubernetes.io/name
+                        operator: In
+                        values:
+                          - authentik
+                          - llama-cpp
+                          - llama-cpp-embeddings
+                      - key: postgres-operator.crunchydata.com/cluster
+                        operator: In
+                        values:
+                          - postgresql
     {{- end }}
 {{- end }}

--- a/charts/services/templates/prowlarr.yaml
+++ b/charts/services/templates/prowlarr.yaml
@@ -30,6 +30,8 @@ spec:
         annotations:
           reloader.stakater.com/auto: "true"
         podSpec:
+          labels:
+            networking.arch-anes.io/egress: tunnel-only
           containers:
             {{- include "tunnel.truecharts.container" . | nindent 12 }}
             main:

--- a/charts/services/templates/stalwart.yaml
+++ b/charts/services/templates/stalwart.yaml
@@ -461,4 +461,28 @@ spec:
       storageClass: local-path-persistent-namespaced
       accessMode: ReadWriteOnce
       size: 10Gi
+
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: stalwart-tempo-egress
+  namespace: "{{ .Values.applicationsNamespace }}"
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: stalwart-mail
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: tempo
+      ports:
+        - protocol: TCP
+          port: 4318
 {{- end }}

--- a/charts/services/templates/transmission.yaml
+++ b/charts/services/templates/transmission.yaml
@@ -63,6 +63,8 @@ spec:
         podSpec:
           annotations:
             backup.velero.io/backup-volumes: config
+          labels:
+            networking.arch-anes.io/egress: tunnel-only
           affinity:
             podAffinity:
               requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
State of things in dev with these changes: https://github.com/arch-anes/self-hosted-services/commit/13fad2c30fbe46ffae3a70572887529039988c98

Current pet peeve: the `192.168.0.0/16` rule is essential for k3s controller communication from helm controller and local path provisionner jobs, otherwise no chart installs and no pvc works. However this makes the assumption that the cluster endpoints have IPs in that range (and not `10.0.0.0/8` for example) and is too permissive: a service running at 6443 can be accessed from any pod in that IP range. The alternative considered was to allow all egress for helm jobs and pvc jobs, but there could be other things breakings that I didn't notice yet. Probably anything that deals with CRDs.